### PR TITLE
Add option 'location'

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 import { ALIASES, DEFAULT_POT_OUTPUT, DEFAULT_HEADERS,
     UNRESOLVED_ACTION, LOCATION } from './defaults';
 const { FAIL, WARN, SKIP } = UNRESOLVED_ACTION;
+const { FULL, FILE, NEVER } = LOCATION;
 import Ajv from 'ajv';
 import gettext from './extractors/tag-gettext';
 import ngettext from './extractors/tag-ngettext';
@@ -13,7 +14,7 @@ const extractConfigSchema = {
     type: ['object', 'null'],
     properties: {
         output: { type: 'string' },
-        location: { type: 'string' },
+        location: { enum: [FULL, FILE, NEVER] },
         headers: {
             properties: {
                 'content-type': { type: 'string' },
@@ -51,7 +52,7 @@ const extractorsSchema = {
     },
 };
 
-const configSchema = {
+export const configSchema = {
     type: 'object',
     properties: {
         extract: extractConfigSchema,
@@ -63,7 +64,7 @@ const configSchema = {
     additionalProperties: false,
 };
 
-function validateConfig(config, schema) {
+export function validateConfig(config, schema) {
     const ajv = new Ajv({ allErrors: true, verbose: true, v5: true });
     const isValid = ajv.validate(schema, config);
     return [isValid, ajv.errorsText(), ajv.errors];

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 import { ALIASES, DEFAULT_POT_OUTPUT, DEFAULT_HEADERS,
-    UNRESOLVED_ACTION } from './defaults';
+    UNRESOLVED_ACTION, LOCATION } from './defaults';
 const { FAIL, WARN, SKIP } = UNRESOLVED_ACTION;
 import Ajv from 'ajv';
 import gettext from './extractors/tag-gettext';
@@ -13,6 +13,7 @@ const extractConfigSchema = {
     type: ['object', 'null'],
     properties: {
         output: { type: 'string' },
+        location: { type: 'string' },
         headers: {
             properties: {
                 'content-type': { type: 'string' },
@@ -117,6 +118,10 @@ class Config {
 
     getHeaders() {
         return (this.config.extract && this.config.extract.headers) || DEFAULT_HEADERS;
+    }
+
+    getLocation() {
+        return (this.config.extract && this.config.extract.location) || LOCATION.FULL;
     }
 
     getOutputFilepath() {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -27,3 +27,8 @@ export const C3POID = 'c-3po';
 
 export const DEFAULT_POT_OUTPUT = 'polyglot_result.pot';
 
+export const LOCATION = {
+    FULL: 'full',
+    FILE: 'file',
+    NEVER: 'never',
+};

--- a/src/extract.js
+++ b/src/extract.js
@@ -20,10 +20,11 @@ export const extractPoEntry = (extractor, nodePath, config, state) => {
     const { node } = nodePath;
     const filename = state.file.opts.filename;
     const poEntry = extractor.extract(nodePath, config);
+    const location = config.getLocation();
 
     if (filename !== 'unknown') {
         const base = `${process.cwd()}${path.sep}`;
-        return applyReference(poEntry, node, filename.replace(base, ''));
+        return applyReference(poEntry, node, filename.replace(base, ''), location);
     }
 
     return poEntry;

--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import gettextParser from 'gettext-parser';
-import { DEFAULT_HEADERS, PO_PRIMITIVES } from './defaults';
+import { DEFAULT_HEADERS, PO_PRIMITIVES, LOCATION } from './defaults';
 
 export function buildPotData(translations) {
     const data = {
@@ -22,11 +22,23 @@ export function buildPotData(translations) {
 }
 
 
-export function applyReference(poEntry, node, filepath) {
+export function applyReference(poEntry, node, filepath, location) {
     if (!poEntry.comments) {
         poEntry.comments = {};
     }
-    poEntry.comments.reference = `${filepath}:${node.loc.start.line}`;
+
+    let reference = null;
+
+    switch (location) {
+        case LOCATION.FILE:
+            reference = filepath; break;
+        case LOCATION.NEVER:
+            reference = null; break;
+        default:
+            reference = `${filepath}:${node.loc.start.line}`;
+    }
+
+    poEntry.comments.reference = reference;
     return poEntry;
 }
 

--- a/tests/unit/test_config.js
+++ b/tests/unit/test_config.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { configSchema, validateConfig } from 'src/config';
+
+
+describe('config validateConfig', () => {
+    it('should be valid', () => {
+        const config = {
+            extract: {
+                output: 'translations.pot',
+                location: 'file',
+            },
+            resolve: { locale: 'en-us' },
+            locales: {
+                'en-us': 'i18n/en.po',
+            },
+        };
+        const expected = [true, 'No errors', null];
+        expect(validateConfig(config, configSchema)).to.eql(expected);
+    });
+
+    it('should not be valid', () => {
+        const config = {
+            extract: {
+                output: 'translations.pot',
+                location: 'bad-location',
+            },
+            resolve: { locale: 'en-us' },
+            locales: {
+                'en-us': 'i18n/en.po',
+            },
+        };
+        const [isValid, errorsText, errors] = validateConfig(config, configSchema);
+        expect(isValid).to.eql(false);
+        expect(errorsText).to.not.equal('No errors');
+        expect(errors[0].data).to.eql('bad-location');
+    });
+});

--- a/tests/unit/test_po-helpers.js
+++ b/tests/unit/test_po-helpers.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { getNPlurals, getPluralFunc, makePluralFunc } from 'src/po-helpers';
+import { getNPlurals, getPluralFunc, makePluralFunc, applyReference } from 'src/po-helpers';
+import { LOCATION } from 'src/defaults';
 
 
 describe('po-helpers getNPlurals', () => {
@@ -37,5 +38,26 @@ describe('po-helpers makePluralFunc', () => {
     it('should return proper plural func', () => {
         const fn = makePluralFunc('n!=1');
         expect(fn(1, ['banana', 'bananas'])).to.eql('banana');
+    });
+});
+
+describe('po-helpers applyReference', () => {
+    const poEntry = {};
+    const filepath = 'filepath';
+    const node = { loc: { start: { line: 3 } } };
+
+    it('should return file name and line number', () => {
+        const expected = { comments: { reference: 'filepath:3' } };
+        expect(applyReference(poEntry, node, filepath, LOCATION.FULL)).to.eql(expected);
+    });
+
+    it('should return file name', () => {
+        const expected = { comments: { reference: 'filepath' } };
+        expect(applyReference(poEntry, node, filepath, LOCATION.FILE)).to.eql(expected);
+    });
+
+    it('should return no lines', () => {
+        const expected = { comments: { reference: null } };
+        expect(applyReference(poEntry, node, filepath, LOCATION.NEVER)).to.eql(expected);
     });
 });


### PR DESCRIPTION
Implementation of GNU xgettext `--add-location` option:

```
‘--add-location=type’
Generate ‘#: filename:line’ lines (default).

The optional type can be either ‘full’, ‘file’, or ‘never’. If it is not given or ‘full’, it generates the lines with both file name and line number. If it is ‘file’, the line number part is omitted. If it is ‘never’, it completely suppresses the lines (same as --no-location).
```

https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html