### PR TITLE
Dev comment extraction does not work because `applyExtractedComments` is never invoked

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -24,7 +24,7 @@ export const extractPoEntry = (extractor, nodePath, config, state) => {
 
     if (filename !== 'unknown') {
         const base = `${process.cwd()}${path.sep}`;
-        return applyReference(poEntry, node, filename.replace(base, ''), location);
+        applyReference(poEntry, node, filename.replace(base, ''), location);
     }
 
     if (config.devCommentsEnabled()) {


### PR DESCRIPTION
In `extract.js#extractPoEntry`, `return applyReference(...)` stops dev comments from being extracted.

In function tests, the use of `babel.transform(input)` skips `if(filename !== 'unknown') {...}` entirely, thus the problem does not surface in functional tests.