### PR TITLE
Traverse up to statement / declaration level to collect dev comments

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -33,7 +33,7 @@ export const extractPoEntry = (extractor, nodePath, config, state) => {
         if (typeof maybeTag === 'string') {
             tag = maybeTag;
         }
-        applyExtractedComments(poEntry, nodePath.parent, tag);
+        applyExtractedComments(poEntry, nodePath, tag);
     }
 
     return poEntry;

--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -54,9 +54,20 @@ export function applyReference(poEntry, node, filepath, location) {
 }
 
 const tagRegex = {};
-export function applyExtractedComments(poEntry, node, tag) {
+export function applyExtractedComments(poEntry, nodePath, tag) {
     if (!poEntry.comments) {
         poEntry.comments = {};
+    }
+
+    const node = nodePath.node;
+
+    if (!(
+        node.type.match(/Statement$/) ||
+        node.type.match(/Declaration$/)
+    )) {
+        // Collect parents' comments
+        //
+        applyExtractedComments(poEntry, nodePath.parentPath, tag);
     }
 
     const comments = node.leadingComments;
@@ -70,7 +81,15 @@ export function applyExtractedComments(poEntry, node, tag) {
             .filter((match) => Boolean(match))
             .map((c) => dedent(c[1]));
     }
-    poEntry.comments.extracted = transComments.join('\n');
+
+    if (transComments.length === 0) return;
+
+    if (poEntry.comments.extracted) {
+        poEntry.comments.extracted += '\n';
+    } else {
+        poEntry.comments.extracted = '';
+    }
+    poEntry.comments.extracted += transComments.join('\n');
 }
 
 export function makePotStr(data) {

--- a/tests/functional/test_extract_developer_comments.js
+++ b/tests/functional/test_extract_developer_comments.js
@@ -68,8 +68,6 @@ describe('Extract developer comments', () => {
         expect(result).to.contain('#. comment3-11'); // 3-12 is too far away, ignore
     });
 
-
-
     it('should not fail if no comments', () => {
         const input = dedent(`
         import { t } from 'c-3po';

--- a/tests/functional/test_extract_developer_comments.js
+++ b/tests/functional/test_extract_developer_comments.js
@@ -40,11 +40,41 @@ describe('Extract developer comments', () => {
         expect(result).to.contain('#. comment1\n#. comment2');
     });
 
+    it('should extract each level of comments', () => {
+        const input = dedent(`
+        import { t } from 'c-3po';
+
+        //comment3-3
+        dispatch( /*comment3-2*/ someAction( /*comment3-1*/ t\`test3-1\` ));
+
+        //comment3-6
+        const formatted = /*comment3-5*/\`foo \${/*comment3-4*/ t\`test3-2\`} bar\`;
+
+        //comment3-8
+        const firstInExpression = /*comment3-7*/ t\`test3-3\` + 'bar';
+
+        //comment3-10
+        const middleOfExpression = 'foo' + /*comment3-9*/ t\`test3-4\`;
+
+        //comment3-12
+        foo(); foo2(); /*comment3-11*/ console.log(t\`test3-5\`)
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('#. comment3-3\n#. comment3-2\n#. comment3-1');
+        expect(result).to.contain('#. comment3-6\n#. comment3-5\n#. comment3-4');
+        expect(result).to.contain('#. comment3-8\n#. comment3-7');
+        expect(result).to.contain('#. comment3-10\n#. comment3-9');
+        expect(result).to.contain('#. comment3-11'); // 3-12 is too far away, ignore
+    });
+
+
+
     it('should not fail if no comments', () => {
         const input = dedent(`
         import { t } from 'c-3po';
-        
-        t\`test3\`
+
+        t\`test4\`
         `);
         babel.transform(input, options);
         const fn = () => fs.readFileSync(output).toString();


### PR DESCRIPTION
Given this:
```js
import { t } from 'c-3po';

//comment3-3
dispatch( /*comment3-2*/ someAction( /*comment3-1*/ t`test3-1` ));
```

Outputs this:
```
msgid ""
msgstr ""
"Content-Type: text/plain; charset=utf-8\n"
"Plural-Forms: nplurals=2; plural=(n!=1);\n"

#. comment3-3
#. comment3-2
#. comment3-1
msgid "test3-1"
msgstr ""
```