### PR TITLE
fix sortByMsgid + tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+SHELL := /bin/bash
 export PATH := $(PWD)/node_modules/.bin:$(PATH)
 export NODE_PATH = ./
 
@@ -70,6 +71,9 @@ test_unit:
 test_entries_sort:
 	$(MOCHA_CMD) ./tests/functional/test_entries_sort.js
 
+test_sorted_entries_sort:
+	$(MOCHA_CMD) ./tests/functional/test_sorted_entries_sort.js
+
 test_empty_config:
 	$(MOCHA_CMD) ./tests/functional/test_empty_config_mode.js
 
@@ -94,6 +98,7 @@ test_fun: test_disabled_scope
 test_fun: test_resolve_when_validation_fails
 test_fun: test_alias_discover
 test_fun: test_entries_sort
+test_fun: test_sorted_entries_sort
 test_fun: test_empty_config
 
 test: test_fun

--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -147,13 +147,3 @@ export function hasUsefulInfo(text) {
     const withoutExpressions = text.replace(nonTextRegexp, '');
     return Boolean(withoutExpressions.match(/\S/));
 }
-
-export function msgidComparator(e1, e2) {
-    if (e1.msgid > e2.msgid) {
-        return 1;
-    }
-    if (e2.msgid > e1.msgid) {
-        return -1;
-    }
-    return 0;
-}

--- a/tests/fixtures/expected_sort_by_msgid_sorted.pot
+++ b/tests/fixtures/expected_sort_by_msgid_sorted.pot
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: tests/fixtures/sort_by_msgid_input.js:2
+#: tests/fixtures/sort_by_msgid_input2.js:3
+msgid "a test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input.js:11
+#: tests/fixtures/sort_by_msgid_input2.js:7
+msgid "b test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input2.js:9
+msgid "c test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input.js:4
+#: tests/fixtures/sort_by_msgid_input.js:5
+#: tests/fixtures/sort_by_msgid_input.js:6
+#: tests/fixtures/sort_by_msgid_input.js:7
+#: tests/fixtures/sort_by_msgid_input.js:8
+#: tests/fixtures/sort_by_msgid_input.js:9
+#: tests/fixtures/sort_by_msgid_input2.js:5
+#: tests/fixtures/sort_by_msgid_input2.js:11
+#: tests/fixtures/sort_by_msgid_input2.js:12
+msgid "s test"
+msgstr ""

--- a/tests/fixtures/sort_by_msgid_input.js
+++ b/tests/fixtures/sort_by_msgid_input.js
@@ -1,0 +1,12 @@
+/* eslint-disable */
+t`a test`;
+
+t`s test`;
+t`s test`;
+t`s test`;
+t`s test`;
+t`s test`;
+t`s test`;
+
+t`b test`;
+

--- a/tests/fixtures/sort_by_msgid_input2.js
+++ b/tests/fixtures/sort_by_msgid_input2.js
@@ -1,0 +1,12 @@
+/* eslint-disable */
+
+t`a test`;
+
+t`s test`;
+
+t`b test`;
+
+t`c test`;
+
+t`s test`;
+t`s test`;

--- a/tests/functional/test_sorted_entries_sort.js
+++ b/tests/functional/test_sorted_entries_sort.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import { expect } from 'chai';
 import * as babel from 'babel-core';
 import fs from 'fs';
@@ -19,16 +20,12 @@ describe('Sorting entries by msgid', () => {
         rmDirSync('debug');
     });
 
-    it('should sort entries by msgid', () => {
-        const expectedPath = 'tests/fixtures/expected_sort.pot';
-        const input = `
-        t\`bbbb\`;
-        t\`aaaaa\`;
-        t\`ccccc\`;
-        t\`fffff\`;
-        t\`eeeee\`;
-        `;
-        babel.transform(input, options);
+    it('should not duplicate reference filenames', () => {
+        const inputFile = 'tests/fixtures/sort_by_msgid_input.js';
+        const inputFile2 = 'tests/fixtures/sort_by_msgid_input2.js';
+        const expectedPath = 'tests/fixtures/expected_sort_by_msgid_sorted.pot';
+        babel.transformFileSync(path.join(process.cwd(), inputFile), options);
+        babel.transformFileSync(path.join(process.cwd(), inputFile2), options);
         const result = fs.readFileSync(output).toString();
         const expected = fs.readFileSync(expectedPath).toString();
         expect(result).to.eql(expected);


### PR DESCRIPTION
Issue - https://github.com/c-3po-org/c-3po/issues/55.

Bug reason:
We had this code that iterated through po entries and merged file references:

```js
for (const trans of translations) {
        if (!defaultContext[trans.msgid]) {
            defaultContext[trans.msgid] = trans;
            continue;
        }
        const oldTrans = defaultContext[trans.msgid];

        // merge references
        if (oldTrans.comments && oldTrans.comments.reference &&
            trans.comments && trans.comments.reference &&
            ! oldTrans.comments.reference.match(trans.comments.reference)) {
            oldTrans.comments.reference = `${oldTrans.comments.reference}\n${trans.comments.reference}`;
        }
    }
```
The tricky part was, that our translations were processed in the same order as babel plugin discovered them, and situation when `trans.comments.reference` already included `oldTrans.comments.reference` was impossible, because `trans` was always the new entry. Sort option breaked that order.

Plans for the future is to change `potEntries` from `plugin.js` file to be and object instead of the array, and to make reference merge while we pushing new entry.