### PR TITLE
added sorting to .po entry's comment reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ test_entries_sort:
 test_sorted_entries_sort:
 	$(MOCHA_CMD) ./tests/functional/test_sorted_entries_sort.js
 
+test_sorted_entries_without_reference_line_num:
+	$(MOCHA_CMD) ./tests/functional/test_sorted_entries_without_reference_line_num.js
+
 test_empty_config:
 	$(MOCHA_CMD) ./tests/functional/test_empty_config_mode.js
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,7 +76,26 @@ export default function () {
                     const oldPoData = poData.translations.context;
                     const newContext = {};
                     const keys = Object.keys(oldPoData).sort();
-                    keys.forEach((k) => { newContext[k] = oldPoData[k]; });
+                    keys.forEach((k) => {
+                        const oldPoEntry = oldPoData[k];
+                        // oldPoEntry has a form:
+                        // {
+                        //     msgid: 'message identifier',
+                        //     msgstr: 'translation string',
+                        //     comments: {
+                        //         reference: 'path/to/file.js:line_number\npath/to/other/file.js:line_number'
+                        //     }
+                        // }
+                        const reference = oldPoEntry.comments.reference;
+
+                        // Here we sort reference entries, this could be useful
+                        // with conf. options extract.location: 'file' and sortByMsgid
+                        // which allow you easily merge .po files from different
+                        // branches of SCM such like git or mercurial.
+                        oldPoEntry.comments.reference = reference.split('\n').sort().join('\n');
+
+                        newContext[k] = oldPoData[k];
+                    });
                     poData.translations.context = newContext;
                 }
                 const potStr = makePotStr(poData);

--- a/tests/fixtures/expected_sort_by_msgid_withou_reference_line_num.pot
+++ b/tests/fixtures/expected_sort_by_msgid_withou_reference_line_num.pot
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: tests/fixtures/sort_by_msgid_input.js
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "a test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input.js
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "b test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "c test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input.js
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "s test"
+msgstr ""

--- a/tests/functional/test_sorted_entries_without_reference_line_num.js
+++ b/tests/functional/test_sorted_entries_without_reference_line_num.js
@@ -1,0 +1,37 @@
+import path from 'path';
+import { expect } from 'chai';
+import * as babel from 'babel-core';
+import fs from 'fs';
+import c3poPlugin from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+
+const output = 'debug/translations.pot';
+const options = {
+    presets: ['es2015'],
+    plugins: [[c3poPlugin, {
+        extract: {
+            output,
+            location: 'file',
+        },
+        discover: ['t'],
+        sortByMsgid: true,
+    }]],
+};
+
+describe('Sorting entries by msgid (with file location, but without line number)', () => {
+    beforeEach(() => {
+        rmDirSync('debug');
+    });
+
+    it('should sort message identifiers and file location comments', () => {
+        const inputFile = 'tests/fixtures/sort_by_msgid_input.js';
+        const inputFile2 = 'tests/fixtures/sort_by_msgid_input2.js';
+        const expectedPath = 'tests/fixtures/expected_sort_by_msgid_withou_reference_line_num.pot';
+        // here we use reverse order of files, expected that references will be sorted
+        babel.transformFileSync(path.join(process.cwd(), inputFile2), options);
+        babel.transformFileSync(path.join(process.cwd(), inputFile), options);
+        const result = fs.readFileSync(output).toString();
+        const expected = fs.readFileSync(expectedPath).toString();
+        expect(result).to.eql(expected);
+    });
+});


### PR DESCRIPTION
Added sort to .po file reference comments.

This could be useful with configuration options **extract.location: 'file'** and **sortByMsgid** which allows easily merge .po files from different branches of SCM such as git or mercurial.