### PR TITLE
Added sorting in .po entry's comment reference (by default)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ test_entries_sort:
 test_sorted_entries_sort:
 	$(MOCHA_CMD) ./tests/functional/test_sorted_entries_sort.js
 
+test_sorted_entries_without_reference_line_num:
+	$(MOCHA_CMD) ./tests/functional/test_sorted_entries_without_reference_line_num.js
+
 test_empty_config:
 	$(MOCHA_CMD) ./tests/functional/test_empty_config_mode.js
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,7 +76,26 @@ export default function () {
                     const oldPoData = poData.translations.context;
                     const newContext = {};
                     const keys = Object.keys(oldPoData).sort();
-                    keys.forEach((k) => { newContext[k] = oldPoData[k]; });
+                    keys.forEach((k) => {
+                        const oldPoEntry = oldPoData[k];
+                        // oldPoEntry has a form:
+                        // {
+                        //     msgid: 'message identifier',
+                        //     msgstr: 'translation string',
+                        //     comments: {
+                        //         reference: 'path/to/file.js:line_number\npath/to/other/file.js:line_number'
+                        //     }
+                        // }
+                        const reference = oldPoEntry.comments.reference;
+
+                        // Here we sort reference entries, this could be useful
+                        // with conf. options extract.location: 'file' and sortByMsgid
+                        // which allow you easily merge .po files from different
+                        // branches of SCM such like git or mercurial.
+                        oldPoEntry.comments.reference = reference.split('\n').sort().join('\n');
+
+                        newContext[k] = oldPoData[k];
+                    });
                     poData.translations.context = newContext;
                 }
                 const potStr = makePotStr(poData);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,7 +5,8 @@ import C3poContext from './context';
 import { extractPoEntry, getExtractor } from './extract';
 import { resolveEntries } from './resolve';
 import { buildPotData, makePotStr } from './po-helpers';
-import { hasDisablingComment, isInDisabledScope, isC3poImport, hasImportSpecifier } from './utils';
+import { hasDisablingComment, isInDisabledScope, isC3poImport,
+    hasImportSpecifier, poReferenceComparator } from './utils';
 import { ALIASES } from './defaults';
 import { ValidationError } from './errors';
 
@@ -89,40 +90,9 @@ export default function () {
                     //     }
                     // }
                     if (poEntry.comments && poEntry.comments.reference) {
-                        const cmp = (x, y) => {
-                            if (/.*:\d+$/.test(x)) {
-                                // reference has a form path/to/file.js:line_number
-                                const firstIdx = x.lastIndexOf(':');
-                                const firstFileRef = x.substring(0, firstIdx);
-                                const firstLineNum = Number(x.substring(firstIdx + 1));
-                                const secondIdx = y.lastIndexOf(':');
-                                const secondFileRef = x.substring(0, secondIdx);
-                                const secondLineNum = Number(x.substring(secondIdx + 1));
-                                if (firstFileRef !== secondFileRef) {
-                                    if (firstFileRef < secondFileRef) {
-                                        return -1;
-                                    }
-                                    return 1;
-                                }
-                                // else
-                                if (firstLineNum < secondLineNum) {
-                                    return -1;
-                                } else if (firstLineNum > secondLineNum) {
-                                    return 1;
-                                }
-                                return 0;
-                            }
-                            // else
-                            if (x < y) {
-                                return -1;
-                            } else if (x > y) {
-                                return 1;
-                            }
-                            return 0;
-                        };
                         poEntry.comments.reference = poEntry.comments.reference
                             .split('\n')
-                            .sort(cmp)
+                            .sort(poReferenceComparator)
                             .join('\n');
                     }
                 });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -90,35 +90,35 @@ export default function () {
                     // }
                     if (poEntry.comments && poEntry.comments.reference) {
                         const cmp = (x, y) => {
-                            if (/.*:\d+$/.test(x)){
+                            if (/.*:\d+$/.test(x)) {
                                 // reference has a form path/to/file.js:line_number
                                 const firstIdx = x.lastIndexOf(':');
                                 const firstFileRef = x.substring(0, firstIdx);
                                 const firstLineNum = Number(x.substring(firstIdx + 1));
                                 const secondIdx = y.lastIndexOf(':');
-                                const secondFileRef = x.substring(0, firstIdx);
-                                const secondLineNum = Number(x.substring(firstIdx + 1));
+                                const secondFileRef = x.substring(0, secondIdx);
+                                const secondLineNum = Number(x.substring(secondIdx + 1));
                                 if (firstFileRef !== secondFileRef) {
                                     if (firstFileRef < secondFileRef) {
                                         return -1;
                                     }
                                     return 1;
-                                } else {
-                                    if (firstIdx < secondIdx) {
-                                        return -1;
-                                    } else if (firstIdx > secondIdx) {
-                                        return 1;
-                                    }
-                                    return 0;
                                 }
-                            } else {
-                                if (x < y) {
+                                // else
+                                if (firstLineNum < secondLineNum) {
                                     return -1;
-                                } else if (x > y) {
+                                } else if (firstLineNum > secondLineNum) {
                                     return 1;
                                 }
                                 return 0;
                             }
+                            // else
+                            if (x < y) {
+                                return -1;
+                            } else if (x > y) {
+                                return 1;
+                            }
+                            return 0;
                         };
                         poEntry.comments.reference = poEntry.comments.reference
                             .split('\n')

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,3 +134,36 @@ export function dedentStr(str) {
     }
     return str;
 }
+
+export function poReferenceComparator(firstPoRef, secondPoRef) {
+    if (/.*:\d+$/.test(firstPoRef)) {
+        // reference has a form path/to/file.js:line_number
+        const firstIdx = firstPoRef.lastIndexOf(':');
+        const firstFileRef = firstPoRef.substring(0, firstIdx);
+        const firstLineNum = Number(firstPoRef.substring(firstIdx + 1));
+        const secondIdx = secondPoRef.lastIndexOf(':');
+        const secondFileRef = secondPoRef.substring(0, secondIdx);
+        const secondLineNum = Number(secondPoRef.substring(secondIdx + 1));
+        if (firstFileRef !== secondFileRef) {
+            if (firstFileRef < secondFileRef) {
+                return -1;
+            }
+            return 1;
+        }
+        // else
+        if (firstLineNum < secondLineNum) {
+            return -1;
+        } else if (firstLineNum > secondLineNum) {
+            return 1;
+        }
+        return 0;
+    }
+    // else
+    // reference has a form path/to/file.js
+    if (firstPoRef < secondPoRef) {
+        return -1;
+    } else if (firstPoRef > secondPoRef) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/fixtures/expected_sort_by_msgid_withou_reference_line_num.pot
+++ b/tests/fixtures/expected_sort_by_msgid_withou_reference_line_num.pot
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: tests/fixtures/sort_by_msgid_input.js
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "a test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input.js
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "b test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "c test"
+msgstr ""
+
+#: tests/fixtures/sort_by_msgid_input.js
+#: tests/fixtures/sort_by_msgid_input2.js
+msgid "s test"
+msgstr ""

--- a/tests/functional/test_sorted_entries_without_reference_line_num.js
+++ b/tests/functional/test_sorted_entries_without_reference_line_num.js
@@ -1,0 +1,37 @@
+import path from 'path';
+import { expect } from 'chai';
+import * as babel from 'babel-core';
+import fs from 'fs';
+import c3poPlugin from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+
+const output = 'debug/translations.pot';
+const options = {
+    presets: ['es2015'],
+    plugins: [[c3poPlugin, {
+        extract: {
+            output,
+            location: 'file',
+        },
+        discover: ['t'],
+        sortByMsgid: true,
+    }]],
+};
+
+describe('Sorting entries by msgid (with file location, but without line number)', () => {
+    beforeEach(() => {
+        rmDirSync('debug');
+    });
+
+    it('should sort message identifiers and file location comments', () => {
+        const inputFile = 'tests/fixtures/sort_by_msgid_input.js';
+        const inputFile2 = 'tests/fixtures/sort_by_msgid_input2.js';
+        const expectedPath = 'tests/fixtures/expected_sort_by_msgid_withou_reference_line_num.pot';
+        // here we use reverse order of files, expected that references will be sorted
+        babel.transformFileSync(path.join(process.cwd(), inputFile2), options);
+        babel.transformFileSync(path.join(process.cwd(), inputFile), options);
+        const result = fs.readFileSync(output).toString();
+        const expected = fs.readFileSync(expectedPath).toString();
+        expect(result).to.eql(expected);
+    });
+});

--- a/tests/unit/test_utils.js
+++ b/tests/unit/test_utils.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import template from 'babel-template';
 import { template2Msgid, msgid2Orig, isInDisabledScope,
-    hasDisablingComment, dedentStr, getMsgid } from 'src/utils';
+    hasDisablingComment, dedentStr, getMsgid, poReferenceComparator } from 'src/utils';
 import { DISABLE_COMMENT } from 'src/defaults';
 
 
@@ -102,5 +102,49 @@ describe('utils getMsgid', () => {
         const a = 0;
         const [strs, exprs] = getStrsExprs`test ${a}`;
         expect(getMsgid(strs, exprs)).to.be.eql('test ${ 0 }');
+    });
+});
+
+describe('utils poReferenceComparator', () => {
+    it('# path/a.js should be less than # path/b.js', () => {
+        expect(poReferenceComparator(
+            '# path/a.js',
+            '# path/b.js'
+        )).to.be.eql(-1);
+    });
+
+    it('# path/b.js should be less than # path/a.js', () => {
+        expect(poReferenceComparator(
+            '# path/b.js',
+            '# path/a.js'
+        )).to.be.eql(1);
+    });
+
+    it('# path/a.js should be equal to # path/a.js', () => {
+        expect(poReferenceComparator(
+            '# path/a.js',
+            '# path/a.js'
+        )).to.be.eql(0);
+    });
+
+    it('# path/a.js:5 should be less than # path/a.js:10', () => {
+        expect(poReferenceComparator(
+            '# path/a.js:5',
+            '# path/a.js:10'
+        )).to.be.eql(-1);
+    });
+
+    it('# path/a.js:10 should be less than # path/a.js:5', () => {
+        expect(poReferenceComparator(
+            '# path/a.js:10',
+            '# path/a.js:5'
+        )).to.be.eql(1);
+    });
+
+    it('# path/a.js:10 should be less than # path/a.js:10', () => {
+        expect(poReferenceComparator(
+            '# path/a.js:10',
+            '# path/a.js:10'
+        )).to.be.eql(0);
     });
 });


### PR DESCRIPTION
Added sort to .po file reference comments.

This could be useful with configuration options **extract.location: 'file'** and **sortByMsgid** which allows easily merge .po files from different branches of SCM such as git or mercurial.