### PR TITLE
Fix multiple run

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
   "rules": {
     "no-unused-expressions": "off",
     "no-unused-vars": ["error", { "varsIgnorePattern": "^_$" }],
-    "prefer-const": ["error", {"destructuring": "all"}]
+    "prefer-const": ["error", {"destructuring": "all"}],
+    "no-underscore-dangle": ["error", {"allow": ["_C3PO_visited"]}]
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ test_extract_developer_comments:
 test_extract_developer_comments_by_tag:
 	$(MOCHA_CMD) ./tests/functional/test_extract_developer_comments_by_tag.js
 
+test_extract_ngettext:
+	$(MOCHA_CMD) ./tests/functional/test_extract_ngettext.js
+
 test_resolve_gettext:
 	$(MOCHA_CMD) ./tests/functional/test_resolve_gettext.js
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ test_extract_developer_comments:
 test_extract_developer_comments_by_tag:
 	$(MOCHA_CMD) ./tests/functional/test_extract_developer_comments_by_tag.js
 
-test_extract_ngettext:
-	$(MOCHA_CMD) ./tests/functional/test_extract_ngettext.js
+test_extract_ngettext_with_multiple_presets:
+	$(MOCHA_CMD) ./tests/functional/test_extract_ngettext_with_multiple_presets.js
 
 test_resolve_gettext:
 	$(MOCHA_CMD) ./tests/functional/test_resolve_gettext.js
@@ -87,6 +87,7 @@ test_fun: test_extract_gettext_with_formatting
 test_fun: test_extract_filename
 test_fun: test_extract_developer_comments
 test_fun: test_extract_developer_comments_by_tag
+test_fun: test_extract_ngettext_with_multiple_presets
 test_fun: test_resolve_gettext
 test_fun: test_resolve_gettext_default
 test_fun: test_resolve_default

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-cli": "6.18.0",
     "babel-core": "6.18.2",
     "babel-preset-es2015": "6.18.0",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-stage-3": "^6.17.0",
     "chai": "3.5.0",
     "eslint": "2.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-c-3po",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "",
   "main": "dist/plugin.js",
   "keywords": [

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,7 +23,7 @@ export default function () {
     let imports = new Set();
 
     function extractOrResolve(nodePath, state) {
-        if (nodePath.node._c3po_visited) {
+        if (nodePath.node._C3PO_visited) { // Should visit each node only once
             return;
         }
         if (isInDisabledScope(nodePath, disabledScopes)) {
@@ -66,7 +66,7 @@ export default function () {
             if (context.isResolveMode()) {
                 resolveEntries(extractor, nodePath, context, state);
             }
-            nodePath.node._c3po_visited = true;
+            nodePath.node._C3PO_visited = true;
         } catch (err) {
             // TODO: handle specific instances of errors
             throw nodePath.buildCodeFrameError(err.message);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -23,6 +23,9 @@ export default function () {
     let imports = new Set();
 
     function extractOrResolve(nodePath, state) {
+        if (nodePath.node._c3po_visited) {
+            return;
+        }
         if (isInDisabledScope(nodePath, disabledScopes)) {
             return;
         }
@@ -63,6 +66,7 @@ export default function () {
             if (context.isResolveMode()) {
                 resolveEntries(extractor, nodePath, context, state);
             }
+            nodePath.node._c3po_visited = true;
         } catch (err) {
             // TODO: handle specific instances of errors
             throw nodePath.buildCodeFrameError(err.message);

--- a/tests/functional/test_extract_ngettext.js
+++ b/tests/functional/test_extract_ngettext.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import * as babel from 'babel-core';
+import fs from 'fs';
+import c3poPlugin from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+
+
+describe('Extract ngettext', () => {
+    before(() => {
+        rmDirSync('debug');
+    });
+
+    it('should extract simple gettext literal (without formatting)', () => {
+        const output = 'debug/translations.pot';
+        const options = {
+            presets: ['es2015', 'react'],
+            plugins: [[c3poPlugin, { extract: { output }, discover: ['ngettext'] }]],
+        };
+        const input = '<div>{ngettext(msgid`test`, `test`, n)}</div>';
+        const transResult = babel.transform(input, options);
+        console.log(transResult.code);
+        const result = fs.readFileSync(output).toString();
+        console.log(result);
+    });
+});

--- a/tests/functional/test_extract_ngettext_with_multiple_presets.js
+++ b/tests/functional/test_extract_ngettext_with_multiple_presets.js
@@ -5,21 +5,21 @@ import c3poPlugin from 'src/plugin';
 import { rmDirSync } from 'src/utils';
 
 
-describe('Extract ngettext', () => {
+describe('Extract ngettext with multiple presets', () => {
     before(() => {
         rmDirSync('debug');
     });
 
-    it('should extract simple gettext literal (without formatting)', () => {
+    it('should extract ngettext with multiple presets', () => {
         const output = 'debug/translations.pot';
         const options = {
             presets: ['es2015', 'react'],
             plugins: [[c3poPlugin, { extract: { output }, discover: ['ngettext'] }]],
         };
         const input = '<div>{ngettext(msgid`test`, `test`, n)}</div>';
-        const transResult = babel.transform(input, options);
-        console.log(transResult.code);
+        babel.transform(input, options);
         const result = fs.readFileSync(output).toString();
-        console.log(result);
+        expect(result).to.contain(
+            `msgid "test"\nmsgid_plural "test"\nmsgstr[0] ""\nmsgstr[1] ""`);
     });
 });


### PR DESCRIPTION
There was a problem while using multiple presets (`es2015` and `react`). c-3po plugin was processing `ngettext` call twice. And it was failing while validation ngettext because es6 syntax was converted to es5:

```bash
 1) Extract ngettext with multiple presets should extract ngettext with multiple presets:
     SyntaxError: unknown: First argument must be tagged template expression. You should use 'msgid' tag
  > 1 | <div>{ngettext(msgid`test`, `test`, n)}</div>
```
Because on a second run `msgid` was transformed to a function call already. 

This problem was not reproducing before because we used to transform to default after `extract` phase, so `ngettext` was replaced with `_tag_ngettext` fun and didn't match on a second run.