### PR TITLE
fix member expression extraction if this is present in member expression

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -41,8 +41,17 @@ export function stripTag(nodePath) {
     }
 }
 
-function getMembersPath(node) {
-    const obj = t.isMemberExpression(node.object) ? getMembersPath(node.object) : node.object.name;
+export function getMembersPath(node) {
+    let obj;
+
+    if (t.isMemberExpression(node.object)) {
+        obj = getMembersPath(node.object);
+    } else if (t.isThisExpression(node.object)) {
+        obj = 'this';
+    } else {
+        obj = node.object.name;
+    }
+
     const prop = node.property.name;
     return `${obj}.${prop}`;
 }

--- a/tests/unit/test_ngettext_extractor.js
+++ b/tests/unit/test_ngettext_extractor.js
@@ -14,6 +14,20 @@ describe('ngettext extract', () => {
         expect(result[MSGID]).to.eql('${ n } banana');
     });
 
+    it('should extract proper msgid1 for member expressions', () => {
+        const node = template('ngettext(msgid`${ state.n } banana`, `${ state.n } bananas`, state.n)'
+        )().expression;
+        const result = ngettext.extract(node, enConfig);
+        expect(result[MSGID]).to.eql('${ state.n } banana');
+    });
+
+    it('should extract proper msgid1 for member expressions with this', () => {
+        const node = template('ngettext(msgid`${ this.state.n } banana`, `${ this.state.n } bananas`, this.state.n)'
+        )().expression;
+        const result = ngettext.extract(node, enConfig);
+        expect(result[MSGID]).to.eql('${ this.state.n } banana');
+    });
+
     it('should extract proper msgidplural', () => {
         const node = template('ngettext(msgid`${ n } banana`, `${ n } bananas`, n)')().expression;
         const result = ngettext.extract(node, enConfig);

--- a/tests/unit/test_utils.js
+++ b/tests/unit/test_utils.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import template from 'babel-template';
 import { template2Msgid, msgid2Orig, isInDisabledScope,
     hasDisablingComment, dedentStr, getMsgid, poReferenceComparator,
-    getMembersPath} from 'src/utils';
+    getMembersPath } from 'src/utils';
 import { DISABLE_COMMENT } from 'src/defaults';
 
 

--- a/tests/unit/test_utils.js
+++ b/tests/unit/test_utils.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import template from 'babel-template';
 import { template2Msgid, msgid2Orig, isInDisabledScope,
-    hasDisablingComment, dedentStr, getMsgid, poReferenceComparator } from 'src/utils';
+    hasDisablingComment, dedentStr, getMsgid, poReferenceComparator,
+    getMembersPath} from 'src/utils';
 import { DISABLE_COMMENT } from 'src/defaults';
 
 
@@ -12,10 +13,30 @@ describe('utils template2Msgid', () => {
         expect(template2Msgid(node)).to.eql(expected);
     });
 
-    it('should extract msgid with expressions', () => {
+    it('should extract msgid without expressions', () => {
         const node = template('t`banana`')().expression;
         const expected = 'banana';
         expect(template2Msgid(node)).to.eql(expected);
+    });
+
+    it('should extract msgid with this in expressions', () => {
+        const node = template('t`${this.user.name} test`')().expression;
+        const expected = '${ this.user.name } test';
+        expect(template2Msgid(node)).to.eql(expected);
+    });
+});
+
+describe('utils getMembersPath', () => {
+    it('should get members path', () => {
+        const node = template('user.name')().expression;
+        const mPath = getMembersPath(node);
+        expect(mPath).to.eql('user.name');
+    });
+
+    it('should get members path with "this"', () => {
+        const node = template('this.user.name')().expression;
+        const mPath = getMembersPath(node);
+        expect(mPath).to.eql('this.user.name');
     });
 });
 


### PR DESCRIPTION
The problem:
```js
t`${ this.user.name } hello`
```
was extracted to `"${ undefined.user.name } hello"` instead of `"${ this.user.name } hello"`
@alxpy 
