### PR TITLE
Context extract

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,6 @@
     "no-unused-expressions": "off",
     "no-unused-vars": ["error", { "varsIgnorePattern": "^_$" }],
     "prefer-const": ["error", {"destructuring": "all"}],
-    "no-underscore-dangle": ["error", {"allow": ["_C3PO_visited"]}]
+    "no-underscore-dangle": ["error", {"allow": ["_C3PO_visited", "_C3PO_GETTEXT_CONTEXT"]}]
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ test_sorted_entries_without_reference_line_num:
 test_empty_config:
 	$(MOCHA_CMD) ./tests/functional/test_empty_config_mode.js
 
+test_contexts_extract:
+	$(MOCHA_CMD) ./tests/functional/test_contexts_extract.js
+
 test_fun: test_extract_gettext
 test_fun: test_extract_gettext_with_formatting
 test_fun: test_extract_filename
@@ -106,6 +109,7 @@ test_fun: test_alias_discover
 test_fun: test_entries_sort
 test_fun: test_sorted_entries_sort
 test_fun: test_empty_config
+test_fun: test_contexts_extract
 
 test: test_fun
 test: test_unit

--- a/src/context.js
+++ b/src/context.js
@@ -35,14 +35,18 @@ class C3poContext {
         if (!validationResult) {
             throw new ConfigValidationError(errorsText);
         }
-        this.aliases = {};
-        this.imports = new Set();
+        this.clear();
         if (this.config.defaultHeaders && typeof this.config.defaultHeaders === 'string') {
             const { headers } = parsePoData(this.config.defaultHeaders);
             this.config.defaultHeaders = headers;
         }
         this.setPoData();
         Object.freeze(this.config);
+    }
+
+    clear() {
+        this.aliases = {};
+        this.imports = new Set();
     }
 
     getAliasFor(funcName) {
@@ -59,6 +63,10 @@ class C3poContext {
         this.aliases = aliases;
     }
 
+    addAlias(funcName, alias) {
+        this.aliases[funcName] = alias;
+    }
+
     setImports(imports) {
         this.imports = imports;
     }
@@ -66,6 +74,10 @@ class C3poContext {
     hasImport(alias) {
         const isInDiscover = this.config.discover && this.config.discover.indexOf(alias) !== -1;
         return this.imports.has(alias) || isInDiscover;
+    }
+
+    addImport(importName) {
+        this.imports.add(importName);
     }
 
     getExtractors() {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -10,11 +10,13 @@ export const ALIASES = {
     gettext: 'gettext',
     ngettext: 'ngettext',
     msgid: 'msgid',
+    context: 'c',
 };
 
 export const PO_PRIMITIVES = {
     MSGSTR: 'msgstr',
     MSGID: 'msgid',
+    MSGCTXT: 'msgctxt',
     MSGID_PLURAL: 'msgid_plural',
 };
 

--- a/src/extract.js
+++ b/src/extract.js
@@ -3,7 +3,7 @@ import { dedentStr } from './utils';
 import path from 'path';
 
 import { PO_PRIMITIVES } from './defaults';
-const { MSGID, MSGSTR } = PO_PRIMITIVES;
+const { MSGID, MSGSTR, MSGCTXT } = PO_PRIMITIVES;
 
 function defaultExtract(msgid) {
     return {
@@ -29,6 +29,11 @@ export const extractPoEntry = (extractor, nodePath, context, state) => {
             extractor.getMsgid(nodePath.node);
         poEntry = defaultExtract(msgid);
     }
+
+    if (nodePath._C3PO_GETTEXT_CONTEXT) {
+        poEntry[MSGCTXT] = nodePath._C3PO_GETTEXT_CONTEXT;
+    }
+
     const location = context.getLocation();
 
     if (filename !== 'unknown') {

--- a/src/gettext-context.js
+++ b/src/gettext-context.js
@@ -1,16 +1,16 @@
 import * as t from 'babel-types';
 import { ast2Str } from './utils';
 
-function isContextCall(node) {
+export function isContextCall(node, context) {
     return (
     t.isTaggedTemplateExpression(node) &&
     t.isMemberExpression(node.tag) &&
     t.isCallExpression(node.tag.object) &&
     t.isIdentifier(node.tag.object.callee) &&
-    node.tag.object.callee.name === 'c');
+    node.tag.object.callee.name === context.getAliasFor('context'));
 }
 
-function isValidContext(nodePath) {
+export function isValidContext(nodePath) {
     const node = nodePath.node;
     const argsLength = node.tag.object.arguments.length;
 
@@ -25,15 +25,4 @@ function isValidContext(nodePath) {
     }
 
     return true;
-}
-
-export function tryMatchContext(cb) {
-    return (nodePath, state) => {
-        const node = nodePath.node;
-        if (isContextCall(node) && isValidContext(nodePath)) {
-            nodePath._C3PO_GETTEXT_CONTEXT = node.tag.object.arguments[0].value;
-            nodePath.node = t.taggedTemplateExpression(node.tag.property, node.quasi);
-        }
-        cb(nodePath, state);
-    };
 }

--- a/src/gettext-context.js
+++ b/src/gettext-context.js
@@ -20,7 +20,24 @@ export function isContextFnCall(node, context) {
     );
 }
 
-export function isValidContext(nodePath) {
+export function isValidFnCallContext(nodePath) {
+    const node = nodePath.node;
+    const argsLength = node.callee.object.arguments.length;
+
+    if (argsLength !== 1) {
+        throw nodePath.buildCodeFrameError(`Context function accepts only 1 argument but has ${argsLength} instead.`);
+    }
+
+    const contextStr = node.callee.object.arguments[0];
+
+    if (!t.isLiteral(contextStr)) {
+        throw nodePath.buildCodeFrameError(`Expected string as a context argument. Actual - "${ast2Str(contextStr)}".`);
+    }
+
+    return true;
+}
+
+export function isValidTagContext(nodePath) {
     const node = nodePath.node;
     const argsLength = node.tag.object.arguments.length;
 

--- a/src/gettext-context.js
+++ b/src/gettext-context.js
@@ -1,0 +1,23 @@
+import * as t from 'babel-types';
+
+
+function isContextCall(node) {
+    return (
+    t.isTaggedTemplateExpression(node) &&
+    t.isMemberExpression(node.tag) &&
+    t.isCallExpression(node.tag.object) &&
+    t.isIdentifier(node.tag.object.callee) &&
+    node.tag.object.callee.name === 'c');
+}
+
+
+export function tryMatchContext(cb) {
+    return (nodePath, state) => {
+        const node = nodePath.node;
+        if (isContextCall(node)) {
+            nodePath._C3PO_GETTEXT_CONTEXT = node.tag.object.arguments[0].value;
+            nodePath.node = t.taggedTemplateExpression(node.tag.property, node.quasi);
+        }
+        cb(nodePath, state);
+    };
+}

--- a/src/gettext-context.js
+++ b/src/gettext-context.js
@@ -1,5 +1,5 @@
 import * as t from 'babel-types';
-
+import { ast2Str } from './utils';
 
 function isContextCall(node) {
     return (
@@ -10,11 +10,27 @@ function isContextCall(node) {
     node.tag.object.callee.name === 'c');
 }
 
+function isValidContext(nodePath) {
+    const node = nodePath.node;
+    const argsLength = node.tag.object.arguments.length;
+
+    if (argsLength !== 1) {
+        throw nodePath.buildCodeFrameError(`Context function accepts only 1 argument but has ${argsLength} instead.`);
+    }
+
+    const contextStr = node.tag.object.arguments[0];
+
+    if (! t.isLiteral(contextStr)) {
+        throw nodePath.buildCodeFrameError(`Expected string as a context argument. Actual - "${ast2Str(contextStr)}".`);
+    }
+
+    return true;
+}
 
 export function tryMatchContext(cb) {
     return (nodePath, state) => {
         const node = nodePath.node;
-        if (isContextCall(node)) {
+        if (isContextCall(node) && isValidContext(nodePath)) {
             nodePath._C3PO_GETTEXT_CONTEXT = node.tag.object.arguments[0].value;
             nodePath.node = t.taggedTemplateExpression(node.tag.property, node.quasi);
         }

--- a/src/gettext-context.js
+++ b/src/gettext-context.js
@@ -1,13 +1,23 @@
 import * as t from 'babel-types';
 import { ast2Str } from './utils';
 
-export function isContextCall(node, context) {
+export function isContextTagCall(node, context) {
     return (
     t.isTaggedTemplateExpression(node) &&
     t.isMemberExpression(node.tag) &&
     t.isCallExpression(node.tag.object) &&
     t.isIdentifier(node.tag.object.callee) &&
     node.tag.object.callee.name === context.getAliasFor('context'));
+}
+
+export function isContextFnCall(node, context) {
+    return (
+        t.isCallExpression(node) &&
+        t.isMemberExpression(node.callee) &&
+        t.isCallExpression(node.callee.object) &&
+        t.isIdentifier(node.callee.object.callee) &&
+        node.callee.object.callee.name === context.getAliasFor('context')
+    );
 }
 
 export function isValidContext(nodePath) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,7 +11,8 @@ import { hasDisablingComment, isInDisabledScope, isC3poImport,
 import { resolveEntries } from './resolve';
 import { ValidationError } from './errors';
 import C3poContext from './context';
-import { isContextTagCall, isValidContext, isContextFnCall } from './gettext-context';
+import { isContextTagCall, isValidTagContext, isContextFnCall,
+    isValidFnCallContext } from './gettext-context';
 
 
 const reverseAliases = {};
@@ -27,7 +28,7 @@ export default function () {
     function tryMatchTag(cb) {
         return (nodePath, state) => {
             const node = nodePath.node;
-            if (isContextTagCall(node, context) && isValidContext(nodePath)) {
+            if (isContextTagCall(node, context) && isValidTagContext(nodePath)) {
                 nodePath._C3PO_GETTEXT_CONTEXT = node.tag.object.arguments[0].value;
                 nodePath.node = bt.taggedTemplateExpression(node.tag.property, node.quasi);
             }
@@ -38,7 +39,7 @@ export default function () {
     function tryMatchCall(cb) {
         return (nodePath, state) => {
             const node = nodePath.node;
-            if (isContextFnCall(node, context)) {
+            if (isContextFnCall(node, context) && isValidFnCallContext(nodePath)) {
                 nodePath._C3PO_GETTEXT_CONTEXT = node.callee.object.arguments[0].value;
                 nodePath.node = bt.callExpression(node.callee.property, node.arguments);
             }

--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -9,18 +9,23 @@ export function buildPotData(translations) {
         charset: 'UTF-8',
         headers: DEFAULT_HEADERS,
         translations: {
-            context: {
+            '': {
             },
         },
     };
 
-    const defaultContext = data.translations.context;
     for (const trans of translations) {
-        if (!defaultContext[trans.msgid]) {
-            defaultContext[trans.msgid] = trans;
+        const ctx = trans[PO_PRIMITIVES.MSGCTXT] || '';
+        if (!data.translations[ctx]) {
+            data.translations[ctx] = {};
+        }
+
+        if (!data.translations[ctx][trans.msgid]) {
+            data.translations[ctx][trans.msgid] = trans;
             continue;
         }
-        const oldTrans = defaultContext[trans.msgid];
+
+        const oldTrans = data.translations[ctx][trans.msgid];
 
         // merge references
         if (oldTrans.comments && oldTrans.comments.reference &&

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import * as babel from 'babel-core';
+import fs from 'fs';
+import c3po from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+import dedent from 'dedent';
+
+const output = 'debug/translations.pot';
+const options = {
+    plugins: [[c3po, { extract: { output } }]],
+};
+
+describe('Contexts extract', () => {
+    before(() => {
+        rmDirSync('debug');
+    });
+
+    it('should extract "t" with context', () => {
+        const input = dedent(`
+            import { c, t } from 'c-3po';
+            c('email').t\`test\`;
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        console.log(result);
+        // expect(result).to.contain('#. test1');
+    });
+});

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -75,4 +75,14 @@ describe('Contexts extract', () => {
         const fn = () => babel.transform(input, options);
         expect(fn).to.throw('Context function accepts only 1 argument but has 2 instead');
     });
+
+    it('should discover context by alias', () => {
+        const input = dedent(`
+            import { c as msgctxt, t } from 'c-3po';
+            msgctxt('phone').t\`test\`;
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('msgctxt "phone"');
+    });
 });

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -55,4 +55,24 @@ describe('Contexts extract', () => {
         const result = fs.readFileSync(output).toString();
         expect(result).to.eql(expect2);
     });
+
+    it('should throw if context argument is not string', () => {
+        const input = dedent(`
+            import { c, t } from 'c-3po';
+            c(aaa).t\`test\`;
+        `);
+
+        const fn = () => babel.transform(input, options);
+        expect(fn).to.throw('Expected string as a context argument. Actual - "aaa"');
+    });
+
+    it('should throw if has more than 1 argument', () => {
+        const input = dedent(`
+            import { c, t } from 'c-3po';
+            c('email', 'profile').t\`test\`;
+        `);
+
+        const fn = () => babel.transform(input, options);
+        expect(fn).to.throw('Context function accepts only 1 argument but has 2 instead');
+    });
 });

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -116,4 +116,15 @@ describe('Contexts extract', () => {
         const fn = () => babel.transform(input, options);
         expect(fn).to.throw('Expected string as a context argument. Actual - "aaa"');
     });
+
+    it('should extract gettext', () => {
+        const input = dedent(`
+            import { c, gettext } from 'c-3po';
+            c('gettext_ctx').gettext('gettext test');
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('msgctxt "gettext_ctx"');
+        expect(result).to.contain('msgid "gettext test"');
+    });
 });

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -10,6 +10,31 @@ const options = {
     plugins: [[c3po, { extract: { output } }]],
 };
 
+const expect1 = `import { c, t } from 'c-3po';
+c('email').t\`test\`;
+console.log(t\`test\`);
+c('email').t\`test2\`;
+console.log(t\`test2\`);`;
+
+const expect2 = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\\n"
+
+msgid "test"
+msgstr ""
+
+msgid "test2"
+msgstr ""
+
+msgctxt "email"
+msgid "test"
+msgstr ""
+
+msgctxt "email"
+msgid "test2"
+msgstr ""`;
+
 describe('Contexts extract', () => {
     before(() => {
         rmDirSync('debug');
@@ -19,10 +44,15 @@ describe('Contexts extract', () => {
         const input = dedent(`
             import { c, t } from 'c-3po';
             c('email').t\`test\`;
+            console.log(t\`test\`);
+            c('email').t\`test2\`;
+            console.log(t\`test2\`);
         `);
-        babel.transform(input, options);
+
+        const babelResult = babel.transform(input, options);
+        expect(babelResult.code).to.eql(expect1);
+
         const result = fs.readFileSync(output).toString();
-        console.log(result);
-        // expect(result).to.contain('#. test1');
+        expect(result).to.eql(expect2);
     });
 });

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -95,6 +95,5 @@ describe('Contexts extract', () => {
         const result = fs.readFileSync(output).toString();
         expect(result).to.contain('msgctxt "ngettext_ctx"');
         expect(result).to.contain('msgid_plural "bananas"');
-
     });
 });

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -85,4 +85,16 @@ describe('Contexts extract', () => {
         const result = fs.readFileSync(output).toString();
         expect(result).to.contain('msgctxt "phone"');
     });
+
+    it('should extract ngettext', () => {
+        const input = dedent(`
+            import { c, ngettext, msgid } from 'c-3po';
+            c('ngettext_ctx').ngettext(msgid\`banana\`, \`bananas\`, n);
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('msgctxt "ngettext_ctx"');
+        expect(result).to.contain('msgid_plural "bananas"');
+
+    });
 });

--- a/tests/functional/test_contexts_extract.js
+++ b/tests/functional/test_contexts_extract.js
@@ -96,4 +96,24 @@ describe('Contexts extract', () => {
         expect(result).to.contain('msgctxt "ngettext_ctx"');
         expect(result).to.contain('msgid_plural "bananas"');
     });
+
+    it('fn call should throw if has more than 1 argument', () => {
+        const input = dedent(`
+        import { c, ngettext, msgid } from 'c-3po';
+        c('ngettext_ctx', 1).ngettext(msgid\`banana\`, \`bananas\`, n);
+        `);
+
+        const fn = () => babel.transform(input, options);
+        expect(fn).to.throw('Context function accepts only 1 argument but has 2 instead');
+    });
+
+    it('fn call should throw if context argument is not string', () => {
+        const input = dedent(`
+        import { c, ngettext, msgid } from 'c-3po';
+        c(aaa).ngettext(msgid\`banana\`, \`bananas\`, n);
+        `);
+
+        const fn = () => babel.transform(input, options);
+        expect(fn).to.throw('Expected string as a context argument. Actual - "aaa"');
+    });
 });

--- a/tests/unit/test_po-helpers.js
+++ b/tests/unit/test_po-helpers.js
@@ -117,6 +117,36 @@ describe('po-helpers buildPotData', () => {
         expect(result).to.eql(expected);
     });
 
+    it('should build po data with multiple contexts', () => {
+        const msg1 = {
+            msgid: 'test',
+            msgstr: 'test1',
+            comments: {
+                reference: 'path/to/file/1.txt:123',
+            },
+        };
+
+        const msg2 = {
+            msgid: 'test2',
+            msgstr: 'test2',
+            msgctxt: 'ctx2',
+            comments: {
+                reference: 'path/to/file/1.txt:123',
+            },
+        };
+
+        const expected = {
+            charset: 'UTF-8',
+            headers: {
+                'content-type': 'text/plain; charset=UTF-8',
+                'plural-forms': 'nplurals=2; plural=(n!=1);',
+            },
+            translations: { '': { test: msg1 }, ctx2: { test2: msg2 } },
+        };
+        const result = buildPotData([msg1, msg2]);
+        expect(result).to.eql(expected);
+    });
+
     it('should accumulate references', () => {
         const msg1 = {
             msgid: 'test',

--- a/tests/unit/test_po-helpers.js
+++ b/tests/unit/test_po-helpers.js
@@ -111,7 +111,7 @@ describe('po-helpers buildPotData', () => {
                 'content-type': 'text/plain; charset=UTF-8',
                 'plural-forms': 'nplurals=2; plural=(n!=1);',
             },
-            translations: { context: { test: msg1 } },
+            translations: { '': { test: msg1 } },
         };
         const result = buildPotData([msg1]);
         expect(result).to.eql(expected);
@@ -147,7 +147,7 @@ describe('po-helpers buildPotData', () => {
                 'content-type': 'text/plain; charset=UTF-8',
                 'plural-forms': 'nplurals=2; plural=(n!=1);',
             },
-            translations: { context: { test: resultmsg } },
+            translations: { '': { test: resultmsg } },
         };
         const result = buildPotData([msg1, msg2]);
         expect(result).to.eql(expected);
@@ -162,7 +162,7 @@ describe('po-helpers buildPotData', () => {
             },
         };
         const result = buildPotData([msg1, msg1]);
-        const ref = result.translations.context.test.comments.reference;
+        const ref = result.translations[''].test.comments.reference;
         expect(ref).to.not.eql('path/to/file/1.txt:123\npath/to/file/1.txt:123');
     });
 });


### PR DESCRIPTION
- [x] context extraction
- [x] test for t, jt, gettext, ngettext
- [x] validation for context (only strings) + tests

js source:
```js
import { c, t } from 'c-3po';

c('email').t`test`;
t`test`;

c('email').t`test2`;
t`test2`;
```
Extracted result in .pot file:
```
msgid ""
msgstr ""
"Content-Type: text/plain; charset=utf-8\\n"
"Plural-Forms: nplurals=2; plural=(n!=1);\\n"

msgid "test"
msgstr ""

msgid "test2"
msgstr ""

msgctxt "email"
msgid "test"
msgstr ""

msgctxt "email"
msgid "test2"
msgstr ""
```
