### PR TITLE
Loosen restrictions on hasUsefulInfo

### DIFF
--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -157,7 +157,7 @@ export function getDefaultPoData(headers) {
     return { headers, translations: { '': {} } };
 }
 
-const nonTextRegexp = /\${.*?}|\d|\s|[.,\/#!$%\^&\*;:{}=\-_`~()]/g;
+const nonTextRegexp = /\${.*?}|\d|\s|[.,\/#!$%\^&\*;{}=\-_`~()]/g;
 export function hasUsefulInfo(text) {
     const withoutExpressions = text.replace(nonTextRegexp, '');
     return Boolean(withoutExpressions.match(/\S/));


### PR DESCRIPTION
### Background

The `babel-plugin-c-3po` loader fails when called with an aspect ratio string like:

```js
t`16:9`
```

This produces a fatal build time error:
> BabelLoaderError: SyntaxError: Can not translate '16:9'
> Error: Can not translate '16:9'

In our application we want to be able to translate aspect ratio strings. For example, in German we may prefer to translate this to `"16 zu 9"`.

### In this PR
 - Update the regexp to allow `:` as a useful character.
