### PR TITLE
Fix upper case variables

### DIFF
--- a/src/extractors/ngettext.js
+++ b/src/extractors/ngettext.js
@@ -103,7 +103,7 @@ function resolveDefault(node, context, state) {
     const args = node.arguments.slice(0, -1).map((quasi) => {
         const quasiStr = getQuasiStr({ quasi });
         const dedentedStr = context.isDedent() ? dedentStr(quasiStr) : quasiStr;
-        return tpl(strToQuasi(dedentedStr))().expression;
+        return tpl.ast(strToQuasi(dedentedStr)).expression;
     });
 
     const nplurals = context.getPluralsCount();
@@ -130,7 +130,7 @@ function resolve(node, translationObj, context, state) {
     if (t.isLiteral(tagArg)) {
         const pluralFn = makePluralFunc(context.getPluralFormula());
         const orig = validateAndFormatMsgid(pluralFn(tagArg.value, args), exprs);
-        return tpl(orig)();
+        return tpl.ast(orig);
     }
 
     return tpl('NGETTEXT(N, ARGS)')({
@@ -140,13 +140,13 @@ function resolve(node, translationObj, context, state) {
             let quasis;
             let expressions;
             if (context.isNumberedExpressions()) {
-                const transNode = tpl(strToQuasi(l))();
+                const transNode = tpl.ast(strToQuasi(l));
                 quasis = transNode.expression.quasis;
                 expressions = transNode.expression.expressions
                     .map(({ value }) => value)
                     .map((i) => msgidTag.quasi.expressions[i]);
             } else {
-                const transNode = tpl(validateAndFormatMsgid(l, exprs))();
+                const transNode = tpl.ast(validateAndFormatMsgid(l, exprs));
                 quasis = transNode.expression.quasis;
                 expressions = transNode.expression.expressions;
             }

--- a/src/extractors/tag-gettext.js
+++ b/src/extractors/tag-gettext.js
@@ -32,7 +32,7 @@ function resolve(node, translation, context) {
     const transStr = translation[MSGSTR][0];
 
     if (hasExpressions(node)) {
-        const transExpr = tpl(strToQuasi(transStr))();
+        const transExpr = tpl.ast(strToQuasi(transStr));
         if (context.isNumberedExpressions()) {
             const exprs = transExpr.expression.expressions
                 .map(({ value }) => value)
@@ -40,7 +40,7 @@ function resolve(node, translation, context) {
             return t.templateLiteral(transExpr.expression.quasis, exprs);
         }
         const exprs = node.quasi.expressions.map(ast2Str);
-        return tpl(validateAndFormatMsgid(transStr, exprs))().expression;
+        return tpl.ast(validateAndFormatMsgid(transStr, exprs)).expression;
     }
     return t.stringLiteral(transStr);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,7 @@ export const getMsgidNumbered = (str, exprs) => str.reduce((s, l, i) => {
 }, '');
 
 export const validateAndFormatMsgid = (msgid, exprNames) => {
-    const msgidAST = tpl(strToQuasi(msgid))();
+    const msgidAST = tpl.ast(strToQuasi(msgid));
     const msgidExprs = new Set(msgidAST.expression.expressions.map(ast2Str));
     exprNames.forEach((exprName) => {
         if (!msgidExprs.has(exprName)) {

--- a/tests/fixtures/resolve_simple_gettext.po
+++ b/tests/fixtures/resolve_simple_gettext.po
@@ -101,3 +101,6 @@ msgstr "test computed ${ a['computed'] } translated"
 #, fuzzy
 msgid "{name} fuzzy name"
 msgstr "{surname} fuzzy name"
+
+msgid "test test ${ MAX_AMOUNT }"
+msgstr "test test ${ MAX_AMOUNT } translate"

--- a/tests/functional/test_resolve_gettext.js
+++ b/tests/functional/test_resolve_gettext.js
@@ -31,6 +31,15 @@ describe('Resolve tag-gettext', () => {
             'console.log("".concat(a, " simple string ").concat(b, " literal with formatting [translated]"))');
     });
 
+    it('should work with upper case characters as variables (regression)', () => {
+        // https://github.com/babel/babel/issues/8723
+        const input = 't`test test ${MAX_AMOUNT}`';
+        const result = babel.transform(input, options).code;
+        expect(result).to.contain(
+            '"test test ".concat(MAX_AMOUNT, " translate");'
+        );
+    });
+
     it('should resolve gettext literal (with formatting) for member expressions', () => {
         const input = (
             'console.log(t`${ item.name.value } simple string ' +


### PR DESCRIPTION
@babel/template 7.x fails when trying ty parse template literal with uppercase variables - https://github.com/babel/babel/issues/8723
This fix is using `ast` function instead of template call.