### PR TITLE
Implemented alias discover for require

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -159,10 +159,19 @@ export default function () {
             VariableDeclarator: (nodePath) => {
                 const { node } = nodePath;
                 if (!isTtagRequire(node)) return;
+
+                // require calls
                 node.id.properties
-                    .map(({ key: { name } }) => name)
-                    .filter((fnName) => ALIAS_TO_FUNC_MAP[fnName])
-                    .forEach((fnName) => context.addImport(fnName));
+                    .map(({ key: { name: keyName }, value: { name: valueName } }) => [keyName, valueName])
+                    .filter(([keyName]) => ALIAS_TO_FUNC_MAP[keyName])
+                    .forEach(([keyName, valueName]) => {
+                        if (keyName !== valueName) { // if alias
+                            context.addAlias(ALIAS_TO_FUNC_MAP[keyName], valueName);
+                            context.addImport(valueName);
+                        } else {
+                            context.addImport(keyName);
+                        }
+                    });
             },
             ImportDeclaration: (nodePath) => {
                 const { node } = nodePath;

--- a/tests/functional/test_discover_by_require.js
+++ b/tests/functional/test_discover_by_require.js
@@ -44,4 +44,14 @@ describe('Extract developer comments', () => {
         const result = fs.readFileSync(output).toString();
         expect(result).to.contain('msgid "test context"');
     });
+
+    it('should recognize alias from require', () => {
+        const input = dedent(`
+        const { t: i18n } = require('ttag');
+        i18n\`test alias\`
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('msgid "test alias"');
+    });
 });


### PR DESCRIPTION
Issue - https://github.com/ttag-org/ttag/issues/120

This syntax is ok for aliasing gettext to i18n:

```js
const { gettext: i18n } = require('ttag')
i18n`test`;
```
