### PR TITLE
Fix macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ test_macro_resolve:
 test_macro_extract:
 	$(MOCHA_CMD) ./tests/functional/test_macro_extract.js
 
+test_alias_extract:
+	$(MOCHA_CMD) ./tests/functional/test_alias_extract.js
+
 
 test_fun: test_extract_gettext
 test_fun: test_extract_fn_gettext
@@ -143,6 +146,7 @@ test_fun: test_resolve_numbered_expressions
 test_fun: test_discover_by_require
 test_fun: test_macro_resolve
 test_fun: test_macro_extract
+test_fun: test_alias_extract
 
 test: test_fun
 test: test_unit

--- a/src/context.js
+++ b/src/context.js
@@ -70,7 +70,11 @@ class C3poContext {
     }
 
     addAlias(funcName, alias) {
-        this.aliases[funcName] = alias;
+        if (this.aliases[funcName]) {
+            this.aliases[funcName].push(alias);
+        } else {
+            this.aliases[funcName] = [alias];
+        }
     }
 
     setImports(imports) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -74,7 +74,7 @@ export default function () {
                 }
                 throw err;
             }
-            
+
             if (context.isExtractMode()) {
                 const poEntry = extractPoEntry(extractor, nodePath, context, state);
                 poEntry && potEntries.push(poEntry);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -14,6 +14,11 @@ import TtagContext from './context';
 import { isContextTagCall, isValidTagContext, isContextFnCall,
     isValidFnCallContext } from './gettext-context';
 
+let started = false;
+export function isStarted() {
+    return started;
+}
+
 export default function () {
     let context;
     let disabledScopes = new Set();
@@ -142,6 +147,7 @@ export default function () {
             TaggedTemplateExpression: tryMatchTag(extractOrResolve),
             CallExpression: tryMatchCall(extractOrResolve),
             Program: (nodePath, state) => {
+                started = true;
                 if (!context) {
                     context = new TtagContext(state.opts);
                 } else {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -74,16 +74,17 @@ export default function () {
                 }
                 throw err;
             }
-
+            
             if (context.isExtractMode()) {
                 const poEntry = extractPoEntry(extractor, nodePath, context, state);
                 poEntry && potEntries.push(poEntry);
+                nodePath.node._C3PO_visited = true;
             }
 
             if (context.isResolveMode()) {
                 resolveEntries(extractor, nodePath, context, state);
+                nodePath.node._C3PO_visited = true;
             }
-            nodePath.node._C3PO_visited = true;
         } catch (err) {
             // TODO: handle specific instances of errors
             throw nodePath.buildCodeFrameError(`${err.message}\n${err.stack}`);

--- a/src/ttag.macro.js
+++ b/src/ttag.macro.js
@@ -1,8 +1,12 @@
 import { createMacro, MacroError } from 'babel-plugin-macros';
 import { FUNC_TO_ALIAS_MAP, ALIAS_TO_FUNC_MAP } from './defaults';
-import plugin from './plugin';
+import { default as plugin, isStarted } from './plugin';
 
 function ttagMacro({ references, state, babel: { types: t }, config = {} }) {
+    const babelPluginTtag = plugin();
+    if (isStarted()) {
+        return { keepImports: true };
+    }
     const program = state.file.path;
 
     // replace `babel-plugin-ttag/macro` by `ttag`, add create a node for ttag's imports
@@ -45,7 +49,8 @@ function ttagMacro({ references, state, babel: { types: t }, config = {} }) {
 
     // apply babel-plugin-ttag to the file
     const stateWithOpts = { ...state, opts: config };
-    program.traverse(plugin().visitor, stateWithOpts);
+    program.traverse(babelPluginTtag.visitor, stateWithOpts);
+    return {};
 }
 
 export default createMacro(ttagMacro, { configName: 'ttag' });

--- a/tests/functional/test_alias_extract.js
+++ b/tests/functional/test_alias_extract.js
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import * as babel from '@babel/core';
+import fs from 'fs';
+import ttag from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+import dedent from 'dedent';
+
+const output = 'debug/translations.pot';
+
+const options = {
+    plugins: [[ttag, { extract: { output } }]],
+};
+
+describe('Contexts extract', () => {
+    before(() => {
+        rmDirSync('debug');
+    });
+
+    it('should extract by alias from import', () => {
+        const input = dedent(`
+        import { t as alias } from 'ttag';
+        alias\`alias extract test\`
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('alias extract test');
+    });
+
+    it('should extract by alias from require', () => {
+        const input = dedent(`
+        const { t: alias } = require('ttag');
+        alias\`alias extract test\`
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('alias extract test');
+    });
+
+    it('should extract with multiple aliases for the same func', () => {
+        const input = dedent(`
+        import { t as alias } from 'ttag';
+        import { t as alias2 } from 'ttag';
+        alias\`alias1 extract test\`
+        alias2\`alias2 extract test\`
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('alias1 extract test');
+        expect(result).to.contain('alias2 extract test');
+  });
+});

--- a/tests/functional/test_alias_extract.js
+++ b/tests/functional/test_alias_extract.js
@@ -47,5 +47,5 @@ describe('Contexts extract', () => {
         const result = fs.readFileSync(output).toString();
         expect(result).to.contain('alias1 extract test');
         expect(result).to.contain('alias2 extract test');
-  });
+    });
 });


### PR DESCRIPTION
## Some fixes to `babel-plugin-ttag`.
This PR fixes some issues from https://github.com/ttag-org/babel-plugin-ttag/pull/115.

  - [x] Set `_C3PO_visited` only when extract or resolve action was performed.
  - [x] Handle multiple aliases for the same file. (added a separate test case for aliases extract)
  - [x] Added `isStarted` flag for the plugin (to avoid multiple simultaneously runs)

## Macro implementation
   - [x] if plugin is already running returning `{ keepImports: true }`.

@cjies I have just tested with CRA and seems it is finally working) 