### PR TITLE
fix: string comparison for reference comments

### DIFF
--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -30,7 +30,7 @@ export function buildPotData(translations) {
         // merge references
         if (oldTrans.comments && oldTrans.comments.reference &&
             trans.comments && trans.comments.reference &&
-            ! oldTrans.comments.reference === trans.comments.reference) {
+            !oldTrans.comments.reference.includes(trans.comments.reference)) {
             oldTrans.comments.reference = `${oldTrans.comments.reference}\n${trans.comments.reference}`;
         }
     }

--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -30,7 +30,7 @@ export function buildPotData(translations) {
         // merge references
         if (oldTrans.comments && oldTrans.comments.reference &&
             trans.comments && trans.comments.reference &&
-            ! oldTrans.comments.reference.match(trans.comments.reference)) {
+            ! oldTrans.comments.reference === trans.comments.reference) {
             oldTrans.comments.reference = `${oldTrans.comments.reference}\n${trans.comments.reference}`;
         }
     }


### PR DESCRIPTION
String.match returns an array, not a boolean value. This resulted in the reference comment being printed multiple times in the resulting .pot file. As a consequence, the .pot file grew unneccessarily large.