### PR TITLE
Remove imports if resolve mode

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,7 +7,7 @@ import { ALIAS_TO_FUNC_MAP } from './defaults';
 import { buildPotData, makePotStr } from './po-helpers';
 import { extractPoEntry, getExtractor } from './extract';
 import { hasDisablingComment, isInDisabledScope, isTtagImport,
-    hasImportSpecifier, poReferenceComparator, isTtagRequire } from './utils';
+    hasImportSpecifier, poReferenceComparator, isTtagRequire, createFnStub } from './utils';
 import { resolveEntries } from './resolve';
 import { ValidationError } from './errors';
 import TtagContext from './context';
@@ -160,14 +160,20 @@ export default function () {
                     disabledScopes.add(nodePath.scope.uid);
                 }
             },
-            VariableDeclarator: (nodePath) => {
+            VariableDeclarator: (nodePath, state) => {
                 const { node } = nodePath;
                 if (!isTtagRequire(node)) return;
-
+                const stubs = [];
                 // require calls
                 node.id.properties
                     .map(({ key: { name: keyName }, value: { name: valueName } }) => [keyName, valueName])
-                    .filter(([keyName]) => ALIAS_TO_FUNC_MAP[keyName])
+                    .filter(([keyName, valueName]) => {
+                        const hasAlias = ALIAS_TO_FUNC_MAP[keyName];
+                        if (!hasAlias) {
+                            stubs.push(valueName);
+                        }
+                        return hasAlias;
+                    })
                     .forEach(([keyName, valueName]) => {
                         if (keyName !== valueName) { // if alias
                             context.addAlias(ALIAS_TO_FUNC_MAP[keyName], valueName);
@@ -177,30 +183,41 @@ export default function () {
                         }
                     });
                 if (context.isResolveMode()) {
+                    stubs.forEach((stub) => {
+                        state.file.path.unshiftContainer('body', createFnStub(stub));
+                    });
                     nodePath.remove();
                 }
             },
             ImportDeclaration: (nodePath, state) => {
                 const { node } = nodePath;
-
+                if (!isTtagImport(node)) return;
                 if (!context) {
                     context = new TtagContext(state.opts);
                 }
-                if (isTtagImport(node)) {
-                    node.specifiers
-                    .filter(({ local: { name } }) => ALIAS_TO_FUNC_MAP[name])
-                    .forEach((s) => context.addImport(s.local.name));
-                }
-                if (isTtagImport(node) && hasImportSpecifier(node)) {
+                const stubs = [];
+                if (hasImportSpecifier(node)) {
                     node.specifiers
                     .filter(bt.isImportSpecifier)
-                    .filter(({ imported: { name } }) => ALIAS_TO_FUNC_MAP[name])
+                    .filter(({ imported, local }) => {
+                        const hasAlias = ALIAS_TO_FUNC_MAP[imported.name];
+                        if (!hasAlias) {
+                            stubs.push(local.name);
+                        }
+                        return hasAlias;
+                    })
                     .forEach(({ imported, local }) => {
                         context.addAlias(ALIAS_TO_FUNC_MAP[imported.name], local.name);
                         context.addImport(local.name);
                     });
+                } else {
+                    throw new Error('You should use ttag imports in form: "import { t } from \'ttag\'"');
                 }
-                if (isTtagImport(node) && context.isResolveMode()) {
+
+                if (context.isResolveMode()) {
+                    stubs.forEach((stub) => {
+                        state.file.path.unshiftContainer('body', createFnStub(stub));
+                    });
                     nodePath.remove();
                 }
             },

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -176,6 +176,9 @@ export default function () {
                             context.addImport(keyName);
                         }
                     });
+                if (context.isResolveMode()) {
+                    nodePath.remove();
+                }
             },
             ImportDeclaration: (nodePath, state) => {
                 const { node } = nodePath;
@@ -196,6 +199,9 @@ export default function () {
                         context.addAlias(ALIAS_TO_FUNC_MAP[imported.name], local.name);
                         context.addImport(local.name);
                     });
+                }
+                if (isTtagImport(node) && context.isResolveMode()) {
+                    nodePath.remove();
                 }
             },
         },

--- a/src/utils.js
+++ b/src/utils.js
@@ -190,3 +190,7 @@ export function poReferenceComparator(firstPoRef, secondPoRef) {
     }
     return 0;
 }
+
+export function createFnStub(name) {
+    return tpl('function NAME(){}')({ NAME: name });
+}

--- a/tests/fixtures/expected_resolve_if_no_extractor_match.js.src
+++ b/tests/fixtures/expected_resolve_if_no_extractor_match.js.src
@@ -1,2 +1,1 @@
-import { t } from "ttag";
 console.log(gtt`simple string literal ${a}`);

--- a/tests/fixtures/ua.po
+++ b/tests/fixtures/ua.po
@@ -14,3 +14,8 @@ msgid_plural "plural form with ${ n } plurals"
 msgstr[0] "plural form with ${ n } plural"
 msgstr[1] "plural form with ${ n } plurals"
 msgstr[2] "plural form with ${ n } plurals"
+
+
+#: tests/fixtures/fixture.js:6
+msgid "test"
+msgstr "test [translated]"

--- a/tests/functional/test_po_resolve.js
+++ b/tests/functional/test_po_resolve.js
@@ -53,5 +53,69 @@ describe('Test po resolve', () => {
         expect(result).not.to.contain('require');
         expect(result).to.contain('test [translated]');
     });
+    it('should add stub for addLocale for require', () => {
+        const options = {
+            plugins: [[ttagPlugin, {
+                resolve: { translations },
+            }]],
+        };
+        const input = `
+        const { t, addLocale } = require("ttag");
+        addLocale('en', {});
+        t\`test\`
+        `;
+        const result = babel.transform(input, options).code;
+        expect(result).not.to.contain('require');
+        expect(result).to.contain('test [translated]');
+        expect(result).to.contain('function addLocale()');
+    });
+    it('should add stub for addLocale for require alias', () => {
+        const options = {
+            plugins: [[ttagPlugin, {
+                resolve: { translations },
+            }]],
+        };
+        const input = `
+        const { t, addLocale: addi18nLocale } = require("ttag");
+        addLocale('en', {});
+        t\`test\`
+        `;
+        const result = babel.transform(input, options).code;
+        expect(result).not.to.contain('require');
+        expect(result).to.contain('test [translated]');
+        expect(result).to.contain('function addi18nLocale()');
+    });
+    it('should add stub for addLocale fun for import', () => {
+        const options = {
+            plugins: [[ttagPlugin, {
+                resolve: { translations },
+            }]],
+        };
+        const input = `
+        import { t, addLocale } from "ttag"
+        t\`test\`
+        addLocale('en', {});
+        `;
+        const result = babel.transform(input, options).code;
+        expect(result).not.to.contain('import');
+        expect(result).to.contain('test [translated]');
+        expect(result).to.contain('function addLocale()');
+    });
+    it('should add stub for addLocale if import specifier', () => {
+        const options = {
+            plugins: [[ttagPlugin, {
+                resolve: { translations },
+            }]],
+        };
+        const input = `
+        import { t, addLocale as addi18nLocale } from "ttag"
+        t\`test\`
+        addi18nLocale('en', {});
+        `;
+        const result = babel.transform(input, options).code;
+        expect(result).not.to.contain('import');
+        expect(result).to.contain('test [translated]');
+        expect(result).to.contain('function addi18nLocale()');
+    });
 });
 

--- a/tests/functional/test_po_resolve.js
+++ b/tests/functional/test_po_resolve.js
@@ -5,20 +5,19 @@ import { rmDirSync } from 'src/utils';
 
 const translations = 'tests/fixtures/ua.po';
 
-const options = {
-    presets: ['@babel/preset-env'],
-    plugins: [[ttagPlugin, {
-        resolve: { translations },
-        discover: ['ngettext'],
-    }]],
-};
-
 describe('Test po resolve', () => {
     before(() => {
         rmDirSync('debug');
     });
 
     it('should resolve proper plural form of n', () => {
+        const options = {
+            presets: ['@babel/preset-env'],
+            plugins: [[ttagPlugin, {
+                resolve: { translations },
+                discover: ['ngettext'],
+            }]],
+        };
         const expected = 'n % 10 == 1 && n % 100 != 11 ? 0 : ' +
             'n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2';
         const input = 'const n = 1; ' +
@@ -35,7 +34,7 @@ describe('Test po resolve', () => {
         const input = `
         import { t } from "ttag"
         t\`test\`
-        `
+        `;
         const result = babel.transform(input, options).code;
         expect(result).not.to.contain('import');
         expect(result).to.contain('test [translated]');
@@ -49,7 +48,7 @@ describe('Test po resolve', () => {
         const input = `
         const { t } = require("ttag");
         t\`test\`
-        `
+        `;
         const result = babel.transform(input, options).code;
         expect(result).not.to.contain('require');
         expect(result).to.contain('test [translated]');

--- a/tests/functional/test_po_resolve.js
+++ b/tests/functional/test_po_resolve.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import * as babel from '@babel/core';
-import c3poPlugin from 'src/plugin';
+import ttagPlugin from 'src/plugin';
 import { rmDirSync } from 'src/utils';
 
 const translations = 'tests/fixtures/ua.po';
 
 const options = {
     presets: ['@babel/preset-env'],
-    plugins: [[c3poPlugin, {
+    plugins: [[ttagPlugin, {
         resolve: { translations },
         discover: ['ngettext'],
     }]],
@@ -25,6 +25,34 @@ describe('Test po resolve', () => {
             'console.log(ngettext(msgid`plural form with ${n} plural`, `plural form with ${n} plurals`, n));';
         const result = babel.transform(input, options).code;
         expect(result).to.contain(expected);
+    });
+    it('should remove imports on resolve', () => {
+        const options = {
+            plugins: [[ttagPlugin, {
+                resolve: { translations },
+            }]],
+        };
+        const input = `
+        import { t } from "ttag"
+        t\`test\`
+        `
+        const result = babel.transform(input, options).code;
+        expect(result).not.to.contain('import');
+        expect(result).to.contain('test [translated]');
+    });
+    it('should remove require on resolve', () => {
+        const options = {
+            plugins: [[ttagPlugin, {
+                resolve: { translations },
+            }]],
+        };
+        const input = `
+        const { t } = require("ttag");
+        t\`test\`
+        `
+        const result = babel.transform(input, options).code;
+        expect(result).not.to.contain('require');
+        expect(result).to.contain('test [translated]');
     });
 });
 


### PR DESCRIPTION
If we are using `resolve` mode, we are assuming that all translations are placed into the build result, and all ttag tags and functions are stripped. So why do we need imports? This PR adds logic that will remove ttag imports and requires. This will allow not to include ttag lib in a resulting bundle.

Example:

```js
import { t } from "ttag"
t`test`;
```
`babel-plugin-ttag` config
```json
{"resolve": { "translations": "./path/to/file.po" } }
```

Output code:

```js
"test [translated]"
```

Will also add stubs for all ttag lib functions:

```js
import { addLocale } from "ttag";

addLocale('en', data);
```

will be

```js
function addLocale() {}

addLocale('en', data);
```
@MrOrz @alxpy @vharitonsky what do you think?
