### PR TITLE
added possibility to sort po entries by msgctxt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ test_unit:
 
 test_entries_sort:
 	$(MOCHA_CMD) ./tests/functional/test_entries_sort.js
+	
+test_entries_sort_by_msgctxt:
+	$(MOCHA_CMD) ./tests/functional/test_entries_sort_by_msgctxt.js
 
 test_sorted_entries_sort:
 	$(MOCHA_CMD) ./tests/functional/test_sorted_entries_sort.js
@@ -139,6 +142,7 @@ test_fun: test_disabled_scope
 test_fun: test_resolve_when_validation_fails
 test_fun: test_alias_discover
 test_fun: test_entries_sort
+test_fun: test_entries_sort_by_msgctxt
 test_fun: test_sorted_entries_sort
 test_fun: test_empty_config
 test_fun: test_contexts_extract

--- a/src/config.js
+++ b/src/config.js
@@ -48,6 +48,7 @@ export const configSchema = {
         defaultLang: { enum: getAvailLangs() },
         addComments: { oneOf: [{ type: 'boolean' }, { type: 'string' }] },
         sortByMsgid: { type: 'boolean' },
+        sortByMsgctxt: { type: 'boolean' },
         numberedExpressions: { type: 'boolean' },
     },
     additionalProperties: false,

--- a/src/context.js
+++ b/src/context.js
@@ -176,6 +176,10 @@ class C3poContext {
         return Boolean(this.config.sortByMsgid);
     }
 
+    isSortedByMsgctxt() {
+        return Boolean(this.config.sortByMsgctxt);
+    }
+
     setPoData() {
         const poFilePath = this.getPoFilePath();
         if (!poFilePath || poFilePath === 'default') {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -133,6 +133,15 @@ export default function () {
                         poData.translations[ctx] = newContext;
                     }
                 }
+                if (context.isSortedByMsgctxt()) {
+                    const unorderedTranslations = poData.translations;
+                    poData.translations = {};
+                    for (const ctx of Object.keys(unorderedTranslations).sort()) {
+                        poData.translations[ctx] = unorderedTranslations[ctx];
+                    }
+                }
+
+
                 const potStr = makePotStr(poData);
                 const filepath = context.getOutputFilepath();
                 const dirPath = path.dirname(filepath);

--- a/tests/fixtures/expected_sort_by_msgctx.pot
+++ b/tests/fixtures/expected_sort_by_msgctx.pot
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+msgctxt "aa"
+msgid "aa"
+msgstr ""
+
+msgctxt "bb"
+msgid "aa"
+msgstr ""
+
+msgctxt "cc"
+msgid "aa"
+msgstr ""
+
+msgctxt "dd"
+msgid "aa"
+msgstr ""
+
+msgctxt "ee"
+msgid "cc"
+msgstr ""
+
+msgctxt "ee"
+msgid "aa"
+msgstr ""

--- a/tests/fixtures/expected_sort_by_msgctxt_and_msgid.pot
+++ b/tests/fixtures/expected_sort_by_msgctxt_and_msgid.pot
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+msgctxt "aa"
+msgid "aa"
+msgstr ""
+
+msgctxt "bb"
+msgid "aa"
+msgstr ""
+
+msgctxt "cc"
+msgid "aa"
+msgstr ""
+
+msgctxt "dd"
+msgid "aa"
+msgstr ""
+
+msgctxt "ee"
+msgid "aa"
+msgstr ""
+
+msgctxt "ee"
+msgid "cc"
+msgstr ""

--- a/tests/functional/test_entries_sort_by_msgctxt.js
+++ b/tests/functional/test_entries_sort_by_msgctxt.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import * as babel from '@babel/core';
+import fs from 'fs';
+import ttag from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+import dedent from 'dedent';
+
+const output = 'debug/translations.pot';
+
+describe('Sorting entries by msgctxt', () => {
+    beforeEach(() => {
+        rmDirSync('debug');
+    });
+
+    it('should sort entries by msgctxt', () => {
+        const options = {
+            presets: ['@babel/preset-env'],
+            plugins: [
+                [
+                    ttag,
+                    {
+                        extract: { output },
+                        sortByMsgctxt: true,
+                        sortByMsgid: false,
+                    },
+                ],
+            ],
+        };
+
+        const expectedPath = 'tests/fixtures/expected_sort_by_msgctx.pot';
+        const input = dedent(`
+            import { c, t } from 'ttag';
+            c('ee').t\`cc\`;
+            c('bb').t\`aa\`;
+            c('ee').t\`aa\`;
+            c('dd').t\`aa\`;
+            c('cc').t\`aa\`;
+            c('aa').t\`aa\`;
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        const expected = fs.readFileSync(expectedPath).toString();
+        expect(result).to.eql(expected);
+    });
+
+    it('should sort entries by msgctxt and msgid', () => {
+        const options = {
+            presets: ['@babel/preset-env'],
+            plugins: [
+                [
+                    ttag,
+                    {
+                        extract: { output },
+                        sortByMsgctxt: true,
+                        sortByMsgid: true,
+                    },
+                ],
+            ],
+        };
+
+        const expectedPath = 'tests/fixtures/expected_sort_by_msgctxt_and_msgid.pot';
+        const input = dedent(`
+            import { c, t } from 'ttag';
+            c('ee').t\`cc\`;
+            c('bb').t\`aa\`;
+            c('ee').t\`aa\`;
+            c('dd').t\`aa\`;
+            c('cc').t\`aa\`;
+            c('aa').t\`aa\`;
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        const expected = fs.readFileSync(expectedPath).toString();
+        expect(result).to.eql(expected);
+    });
+});


### PR DESCRIPTION
The ability to sort po entries by message ids is pretty awesome to prevent merge conflicts, however I experienced issues when using different message contexts.
By giving the possibility to sort the context blocks, there should be less merge conflicts when using different contexts.