### PR TITLE
Fixed require discover logic. (was broken by babel 7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - 6
   - 8
   - node
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,7 +7,7 @@ import { ALIAS_TO_FUNC_MAP } from './defaults';
 import { buildPotData, makePotStr } from './po-helpers';
 import { extractPoEntry, getExtractor } from './extract';
 import { hasDisablingComment, isInDisabledScope, isTtagImport,
-    hasImportSpecifier, poReferenceComparator, isTtagRequire, createFnStub, ast2Str } from './utils';
+    hasImportSpecifier, poReferenceComparator, isTtagRequire, createFnStub } from './utils';
 import { resolveEntries } from './resolve';
 import { ValidationError } from './errors';
 import TtagContext from './context';

--- a/tests/fixtures/test_require_discover.js
+++ b/tests/fixtures/test_require_discover.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+
+const { t } = require('ttag');
+console.log(t`starting count up to`);

--- a/tests/functional/test_discover_by_require.js
+++ b/tests/functional/test_discover_by_require.js
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
 import * as babel from '@babel/core';
 import fs from 'fs';
+import dedent from 'dedent';
+import path from 'path';
 import c3po from 'src/plugin';
 import { rmDirSync } from 'src/utils';
-import dedent from 'dedent';
+
 
 const output = 'debug/translations.pot';
 const options = {
@@ -23,6 +25,13 @@ describe('Extract developer comments', () => {
         babel.transform(input, options);
         const result = fs.readFileSync(output).toString();
         expect(result).to.contain('msgid "test"');
+    });
+
+    it('should extreact t from require from file', () => {
+        const inputFile = 'tests/fixtures/test_require_discover.js';
+        babel.transformFileSync(path.join(process.cwd(), inputFile), options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.include('starting count up to');
     });
 
     it('should extract jt from require', () => {


### PR DESCRIPTION
this PR fixes issue - https://github.com/ttag-org/ttag/issues/194
As I suppose, babel 7 introduced a different logic for plugins to be applied, and while we actually discover 'VariableDeclarator' node - object destructuring transform had already happened.