### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/generator": "^7.9.5",
     "@babel/template": "^7.8.6",
     "@babel/types": "^7.9.5",
-    "ajv": "4.9.0",
+    "ajv": "6.12.3",
     "babel-plugin-macros": "^2.8.0",
     "dedent": "0.6.0",
     "gettext-parser": "4.0.0-alpha.0",


### PR DESCRIPTION
Prototype Pollution: ajv is vulnerable to prototype pollution. The vulnerability exists as it does not prevent the overwrite of `proto` properties.