### PR TITLE
Support comments before strings inside JSX

### DIFF
--- a/tests/functional/test_extract_developer_comments_by_tag.js
+++ b/tests/functional/test_extract_developer_comments_by_tag.js
@@ -7,6 +7,7 @@ import dedent from 'dedent';
 
 const output = 'debug/translations.pot';
 const options = {
+    presets: ['@babel/preset-env', "@babel/preset-react"],
     plugins: [[ttag, { extract: { output }, addComments: 'translator:' }]],
 };
 
@@ -49,5 +50,46 @@ describe('Extract developer comments by tag', () => {
         babel.transform(input, options);
         const result = fs.readFileSync(output).toString();
         expect(result).to.contain('#. test-comment');
+    });
+    it('should extract comments inside JSX tags', () => {
+        const input = dedent(`
+              import { c } from 'ttag';
+
+
+              function render() {
+                return (<>
+                    <h1>{
+                      // translator: this comment is for you AND IT WILL WORK
+                      c('valid-comment-1').t\`Title de ouf\`
+                    }</h1>
+
+                    <h2>{
+                      // this comment is NOT for you 
+                      c('invalid-comment').t\`Title de ouf pas ok?\`
+                    }</h2>
+                    <h2>{
+                      /* translator: OKAY this comment is for you */
+                      c('valid-comment-2').t\`Title de ouf ok?\`
+                    }</h2>
+
+                  <h3>{c('no-comment').t\`hahaha\`}</h3>
+                </>)
+
+              }
+          `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('#. OKAY this comment is for you');
+        expect(result).to.contain('#. this comment is for you AND IT WILL WORK');
+        expect(result).not.to.contain('#. this comment is NOT for you');
+
+        const entries = result.split('\n\n')
+
+        const validComment1 = entries.find((text) => text.includes('valid-comment-1'))
+        const noComment = entries.find((text) => text.includes('no-comment'))
+        const invalidComment = entries.find((text) => text.includes('invalid-comment'))
+        expect(noComment).not.to.contain('#.')
+        expect(invalidComment).not.to.contain('#.')
+        expect(validComment1).to.contain('#. this comment is for you AND IT WILL WORK');
     });
 });


### PR DESCRIPTION
Hey :wave: 

We have an issue with ttag not able to export comments for a string if they are inside a JSX node. (via `ttag-cli extract`) 

cf 
```jsx
function render() {
  return (<>
      <h1>{
        // translator: this comment is for you AND IT WILL WORK
        c('valid-comment-1').t\`Title de ouf\`
      }</h1>
      <h2>{
        // this comment is NOT for you 
        c('invalid-comment').t\`Title de ouf pas ok?\`
      }</h2>
      <h2>{
        /* translator: OKAY this comment is for you */
        c('valid-comment-2').t\`Title de ouf ok?\`
      }</h2>
    <h3>{c('no-comment').t\`hahaha\`}</h3>
  </>)
}
``` 

Test added:
``` 
$ make test_extract_developer_comments_by_tag                                                                      
mocha --require @babel/register ./tests/functional/test_extract_developer_comments_by_tag.js                       
                                                                                                                   
                                                                                                                   
  Extract developer comments by tag                                                                                
    ✓ should extract comment comment (419ms)                                                                       
    ✓ should not extract comment                                                                                   
    ✓ should match with spaces after //                                                                            
    ✓ should extract comments inside JSX tags                                                                      
                                                                                                                   
                                                                                                                   
  4 passing (548ms)                                                                                                
                                                                                                                   ```
