### PR TITLE
Hotfix: leadingComments property can be null

### DIFF
--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -76,7 +76,9 @@ export function applyReference(poEntry, node, filepath, location) {
  *  @returns Array comments
 */
 const extractComment = (nodePath, comments = []) => {
-    if (comments.length) {
+    
+    // Can be null cf https://github.com/babel/babel/blob/main/packages/babel-types/scripts/generators/typescript-legacy.js#L39
+    if (comments?.length) {
         return comments;
     }
 


### PR DESCRIPTION
Hey :wave: 

Post merge of https://github.com/ttag-org/babel-plugin-ttag/pull/162 (thx :pray: ) we updated one of our projects with the dep and found an issue. 

```
Running ttag extract
SyntaxError: /builds/web/clients/applications/calendar/i18n-js/packages/components/components/collapsible/CollapsibleHeaderButton.tsx: Cannot read properties of null (reading 'length')
TypeError: Cannot read properties of null (reading 'length')
    at extractComment (/builds/web/clients/node_modules/babel-plugin-ttag/dist/po-helpers.js:134:16)
    at applyExtractedComments (/builds/web/clients/node_modules/babel-plugin-ttag/dist/po-helpers.js:160:18)
    at applyExtractedComments (/builds/web/clients/node_modules/babel-plugin-ttag/dist/po-helpers.js:157:5)
    at applyExtractedComments (/builds/web/clients/node_modules/babel-plugin-ttag/dist/po-helpers.js:157:5)
    at applyExtractedComments (/builds/web/clients/node_modules/babel-plugin-ttag/dist/po-helpers.js:157:5)
    at extractPoEntry (/builds/web/clients/node_modules/babel-plugin-ttag/dist/extract.js:69:43)
    at extractOrResolve (/builds/web/clients/node_modules/babel-plugin-ttag/dist/plugin.js:129:51)
    at PluginPass.<anonymous> (/builds/web/clients/node_modules/babel-plugin-ttag/dist/plugin.js:78:7)
    at newFn (/builds/web/clients/node_modules/@babel/traverse/lib/visitors.js:159:21)
    at NodePath._call (/builds/web/clients/node_modules/@babel/traverse/lib/path/context.js:46:20)
  20 |
  21 | const CollapsibleHeaderButton = ({
> 22 |     expandText = c('Collapsible tooltip').t`Expand`,
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  23 |     collapseText = c('Collapsible tooltip').t`Collapse`,
  24 |     children,
  25 |     disabled,
    at File.buildCodeFrameError (/builds/web/clients/node_modules/@babel/core/lib/transformation/file/file.js:209:12)
    at NodePath.buildCodeFrameError (/builds/web/clients/node_modules/@babel/traverse/lib/path/index.js:106:21)
    at extractOrResolve (/builds/web/clients/node_modules/babel-plugin-ttag/dist/plugin.js:138:22)
    at PluginPass.<anonymous> (/builds/web/clients/node_modules/babel-plugin-ttag/dist/plugin.js:78:7)
    at newFn (/builds/web/clients/node_modules/@babel/traverse/lib/visitors.js:159:21)
    at NodePath._call (/builds/web/clients/node_modules/@babel/traverse/lib/path/context.js:46:20)
    at NodePath.call (/builds/web/clients/node_modules/@babel/traverse/lib/path/context.js:36:17)
    at NodePath.visit (/builds/web/clients/node_modules/@babel/traverse/lib/path/context.js:84:31)
    at TraversalContext.visitQueue (/builds/web/clients/node_modules/@babel/traverse/lib/context.js:96:16)
    at TraversalContext.visitSingle (/builds/web/clients/node_modules/@babel/traverse/lib/context.js:72:19) {
  code: 'BABEL_TRANSFORM_ERROR'
}
✖ Failed to extract translations
``` 
> cf [broken file](https://github.com/ProtonMail/WebClients/blob/main/packages/components/components/collapsible/CollapsibleHeaderButton.tsx#L22)

I didn't find a use-case to replicate this behavior inside the tests. As we use TS, I tried to add it inside the babel config for the test + with the same broken component, but the tests are still green :cry: 

As the type is explicit with the value able to be null, there was a bug to fix, to prevent the issue.
