### PR TITLE
Fix expression string check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ debug
 dist
 coverage
 .DS_Store
+.vscode

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ import { ValidationError, NoExpressionError } from './errors';
 
 const disableRegExp = new RegExp(`\\b${DISABLE_COMMENT}\\b`);
 
-const exprReg = /\$\{\s?[\w\W]+?\s}/g;
+const exprReg = /\$\{\s?[\w\W]+?\s}/;
 
 export function strHasExpr(str) {
     return exprReg.test(str);

--- a/tests/unit/test_utils.js
+++ b/tests/unit/test_utils.js
@@ -224,8 +224,10 @@ describe('utils getMsgid', () => {
 
 describe('utils strHasExpr', () => {
     it('should return true if has expressions', () => {
-        const str = 'test match ${ a } and ${ b[0].name }';
-        expect(strHasExpr(str)).to.be.true;
+        const str1 = 'test match ${ a } and ${ b[0].name }';
+        expect(strHasExpr(str1)).to.be.true;
+        const str2 = 'test match 2 ${ a }';
+        expect(strHasExpr(str2)).to.be.true;
     });
     it('should return false if has no expressions', () => {
         const str = 'test no match';


### PR DESCRIPTION
Fix issue where ttag would not set `javascript-format` flag for some translations