### PR TITLE
feat: handle deno npm: specifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,9 @@ test_macro_resolve:
 test_macro_extract:
 	$(MOCHA_CMD) ./tests/functional/test_macro_extract.js
 
+test_npm_specifiers_extract:
+	$(MOCHA_CMD) ./tests/functional/test_npm_specifiers_extract.js
+
 test_alias_extract:
 	$(MOCHA_CMD) ./tests/functional/test_alias_extract.js
 
@@ -155,6 +158,7 @@ test_fun: test_macro_resolve
 test_fun: test_macro_extract
 test_fun: test_alias_extract
 test_fun: test_extract_js_format
+test_fun: test_npm_specifiers_extract
 
 test: test_fun
 test: test_unit

--- a/src/utils.js
+++ b/src/utils.js
@@ -132,9 +132,13 @@ export function hasDisablingComment(node) {
 }
 
 export function isTtagImport(node) {
-    return node.source.value === TTAGID
-        || node.source.value === TTAG_MACRO_ID
-        || node.source.value === INTERNAL_TTAG_MACRO_ID;
+    const { value } = node.source;
+    return value === TTAGID
+        || value.startsWith(`npm:${TTAGID}`)
+        || value === TTAG_MACRO_ID
+        || value.startsWith(`npm:${TTAG_MACRO_ID}`)
+        || value === INTERNAL_TTAG_MACRO_ID
+        || value.startsWith(`npm:${INTERNAL_TTAG_MACRO_ID}`);
 }
 
 export function isTtagRequire(node) {

--- a/tests/functional/test_npm_specifiers_extract.js
+++ b/tests/functional/test_npm_specifiers_extract.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import * as babel from '@babel/core';
+import fs from 'fs';
+import ttag from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+import dedent from 'dedent';
+
+const output = 'debug/translations.pot';
+const options = {
+    plugins: [[ttag, { extract: { output } }]],
+};
+
+const expect2 = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\\n"
+
+msgid "test"
+msgstr ""
+`;
+
+describe('Deno npm: specifiers extract', () => {
+    before(() => {
+        rmDirSync('debug');
+    });
+
+    it('should extract translations from specifiers', () => {
+        const input = dedent(`
+            import { t } from 'npm:ttag@1.8.6';
+            console.log(t\`test\`);
+        `);
+
+        const babelResult = babel.transform(input, options);
+        expect(babelResult.code).to.eql(input);
+
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.eql(expect2);
+    });
+});


### PR DESCRIPTION
When importing ttag package in Deno we need to use npm: specifiers, this PR adds support to discover those imports 

https://docs.deno.com/runtime/manual/node/npm_specifiers