### PR TITLE
make isFuzzy return true if tag string includes "fuzzy"

### DIFF
--- a/src/po-helpers.js
+++ b/src/po-helpers.js
@@ -190,7 +190,8 @@ export function hasTranslations(translationObj) {
 export function isFuzzy(translationObj) {
     return (
         translationObj && translationObj.comments
-        && translationObj.comments.flag === 'fuzzy');
+        && translationObj.comments.flag
+        && translationObj.comments.flag.includes('fuzzy'));
 }
 
 export function pluralFnBody(pluralStr) {


### PR DESCRIPTION
Some editors turn the `#, javascript-format` into `#, fuzzy, javascript-format` when they merge.
ttag doesn't understand that and doesn't treat them as fuzzy.

fix #178