### PR TITLE
ESM support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ export NODE_PATH = ./
 
 MOCHA_CMD = mocha --require @babel/register
 
+test_esm_extract:
+	$(MOCHA_CMD) ./tests/functional/test_esm_extract.js
+
 test_extract_gettext:
 	$(MOCHA_CMD) ./tests/functional/test_extract_gettext_simple.js
 
@@ -121,7 +124,7 @@ test_alias_extract:
 test_extract_js_format:
 	$(MOCHA_CMD) ./tests/functional/test_extract_js_format.js
 
-
+test_fun: test_esm_extract
 test_fun: test_extract_gettext
 test_fun: test_extract_fn_gettext
 test_fun: test_extract_gettext_with_formatting

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -25,6 +25,8 @@ export const ALIAS_TO_FUNC_MAP = Object.keys(FUNC_TO_ALIAS_MAP).reduce((obj, key
     return obj;
 }, {});
 
+export const FUNC_ALIASES = () => Object.values(FUNC_TO_ALIAS_MAP).flat();
+
 export const PO_PRIMITIVES = {
     MSGSTR: 'msgstr',
     MSGID: 'msgid',

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
 
-import { ALIAS_TO_FUNC_MAP } from './defaults';
+import { ALIAS_TO_FUNC_MAP, FUNC_ALIASES } from './defaults';
 import { buildPotData, makePotStr } from './po-helpers';
 import { extractPoEntry, getExtractor } from './extract';
 import {
@@ -230,7 +230,9 @@ export default function ttagPlugin() {
                             context.addImport(local.name);
                         });
                 } else {
-                    throw new Error('You should use ttag imports in form: "import { t } from \'ttag\'"');
+                    FUNC_ALIASES().forEach((value) => {
+                        context.addImport(value);
+                    });
                 }
 
                 if (context.isResolveMode()) {

--- a/tests/functional/test_esm_extract.js
+++ b/tests/functional/test_esm_extract.js
@@ -26,14 +26,4 @@ describe('ESM extract', () => {
         const result = fs.readFileSync(output).toString();
         expect(result).to.contain('import default extract test');
     });
-
-    it('should extract directly from the default import', () => {
-        const input = dedent(`
-        import ttag from 'ttag';
-        ttag.t\`default extract test\`
-        `);
-        babel.transform(input, options);
-        const result = fs.readFileSync(output).toString();
-        expect(result).to.contain('default extract test');
-    });
 });

--- a/tests/functional/test_esm_extract.js
+++ b/tests/functional/test_esm_extract.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import * as babel from '@babel/core';
+import fs from 'fs';
+import ttag from 'src/plugin';
+import { rmDirSync } from 'src/utils';
+import dedent from 'dedent';
+
+const output = 'debug/translations.pot';
+
+const options = {
+    plugins: [[ttag, { extract: { output } }]],
+};
+
+describe('ESM extract', () => {
+    before(() => {
+        rmDirSync('debug');
+    });
+
+    it('should extract by default import', () => {
+        const input = dedent(`
+        import defaultTtag from 'ttag';
+        const {t} = defaultTtag;
+        t\`import default extract test\`
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('import default extract test');
+    });
+
+    it('should extract directly from the default import', () => {
+        const input = dedent(`
+        import ttag from 'ttag';
+        ttag.t\`default extract test\`
+        `);
+        babel.transform(input, options);
+        const result = fs.readFileSync(output).toString();
+        expect(result).to.contain('default extract test');
+    });
+});


### PR DESCRIPTION
@AlexMost 
Been using ttag recently, was disappointed gettext couldn't support my Javascript/Typescript codebase.

Just experimenting with the babel plugins, not written any babel plugins before so your feedback would be very helpful 🙏 

----

## Changes to `/src`

My thinking is that if we've got a `ImportDeclaration` which passes the `if (!isTtagImport(node)) return;` then we cna be pretty sure there is an intent from the developer to be using `ttag` for localization.

Rather than throwing `You should use ttag imports in form: "import { t } from \'ttag\'"` we can import the default alias names so that we can catch `t, gettext,  ngettext,...` 

## Tests added

[Will update..]